### PR TITLE
Small-SMEM GPU support (SM120 99KB/block) + ms-swift integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ Covers both **Gemma-4-E2B (dense)** and **Gemma-4-26B-A4B (MoE)** attention
 shapes — the MoE router is upstream of attention, so the kernel sees the
 same Q/K/V tensors and only the head counts / window size differ.
 
+## Small-SMEM GPU support (workstation Blackwell, SM120) + ms-swift integration
+
+The default tile configs are tuned for H100's **228KB** shared memory per
+block; workstation Blackwell cards (RTX PRO 6000 / RTX 5090 class, SM120) only
+have **99KB**, and the stock D=512 config needs 144KB → compile-time
+`OutOfResources`. This adds:
+
+- **`_SMALL_SMEM` auto-detection** in `flash_attn/attention.py`: GPUs with
+  <140KB SMEM/block get shrunken tile configs at all four launch sites
+  (fwd ×2, bwd dq, bwd dkv). Same math, smaller tiles. H100+ is unaffected.
+- **ms-swift integration**: `integrations/ms_swift/triton_attn_patch.py` +
+  guide in [`docs/ms-swift-integration.md`](docs/ms-swift-integration.md) —
+  one `--custom_register_path` flag routes all Gemma-4 attention through the
+  kernel (handles the `flash_attn` wheel name collision).
+
+Measured on RTX PRO 6000 Blackwell (SM120, 99KB, bf16), gemma-4-12B:
+
+| Benchmark | Triton | SDPA | Speedup |
+|---|---|---|---|
+| Kernel fwd+bwd, D=512 full causal, N=4K | 30.9ms | 79.1ms | **2.6×** |
+| Kernel fwd+bwd, D=256 SWA(1024), N=4K | 4.2ms | 39.1ms | **9.2×** |
+| **E2E DPO training** (LoRA r64, max_len 8192, step-aligned) | 8m03s/34 steps | 11m51s/34 steps | **1.47×** |
+
+Correctness on this card: fwd |Δ|≤0.008, grads |Δ|≤0.031 vs SDPA; training
+step-1 loss identical (0.8197). Bonus: SDPA's D=512 math path materialises an
+fp32 N×N score tensor (8 GiB at N=8192) — the flash-style kernel eliminates
+that spike entirely, fixing our real-world training OOM.
+
 ## Results at a glance (H100, single GPU)
 
 | Benchmark | Config | Peak speedup / saving |

--- a/docs/ms-swift-integration.md
+++ b/docs/ms-swift-integration.md
@@ -1,0 +1,80 @@
+# 在 ms-swift 里使用本 kernel（含小 SMEM 工作站卡支持）
+
+> 实测环境：ms-swift 4.3.2 · transformers 5.12 · torch 2.11+cu130 · triton 3.6 ·
+> RTX PRO 6000 Blackwell Server (SM120, 99KB SMEM/block) · gemma-4-12B (`gemma4_unified`)
+
+## TL;DR
+
+```bash
+swift rlhf \
+    --rlhf_type dpo \
+    --attn_impl sdpa \
+    --custom_register_path /path/to/repo/integrations/ms_swift/triton_attn_patch.py \
+    ...其余参数不变
+```
+
+一行 `--custom_register_path` 接入，`--attn_impl` 保持 `sdpa`。patch 在进程内把
+transformers 的 `ALL_ATTENTION_FUNCTIONS["sdpa"]` 换成本仓库 kernel：Gemma-4 的
+40 个 sliding (D=256, SWA) 层和 8 个 global (D=512) 层全部走 Triton flash；
+dropout>0 / softcap / 生成期短序列自动回退原生 SDPA。
+
+## 为什么需要它（SDPA 的两个问题）
+
+1. **D=512 无 fused kernel**：SDPA 对 head_dim=512 走 math 路径，物化 **fp32 N×N**
+   分数矩阵 —— N=8192、batch 2、16 头时是 **8.0 GiB 的瞬时尖峰**，在 95GB 卡上
+   基线 88GB 的训练直接 OOM（我们就是这么炸的）。
+2. **sliding 层无 SWA fast path**：滑窗只能靠 4D mask 表达，长序列下 kernel 级
+   慢 9 倍以上。
+
+本 kernel 两类层都是 flash 式 **O(N) 内存**：尖峰结构性消除，OOM 根治。
+
+## 实测数字（RTX PRO 6000 Blackwell, bf16）
+
+**kernel 级**（B=2, Hq=16, Hkv=8, N=4096, fwd+bwd）：
+
+| 形状 | Triton | SDPA | 提速 | 正确性 |
+|---|---|---|---|---|
+| D=512 full causal | 30.9ms | 79.1ms | **2.6×** | fwd \|Δ\|≤0.008, grads \|Δ\|≤0.031 |
+| D=256 SWA(1024) | 4.2ms | 39.1ms | **9.2×** | 同上 |
+
+**E2E 训练**（gemma-4-12B DPO, LoRA r64, max_len 8192, grad ckpt, grad_accum 3；
+同数据同 seed 逐 step 对齐 34 步）：
+
+| | 到 step34 | 提速 |
+|---|---|---|
+| SDPA | 11m51s | — |
+| Triton | **8m03s** | **1.47×**（分段稳定 1.41–1.51×） |
+
+step-1 loss 与 SDPA 精确一致（0.8197 = 0.8197）；后续发散为 bf16 混沌，属正常。
+
+## 小 SMEM GPU 支持（本 fork 的核心改动）
+
+上游 tile 配置按 H100 (228KB SMEM/block) 调优；工作站 Blackwell 只有 **99KB**，
+D=512 fwd 直接 `OutOfResources`（需 144KB）。`flash_attn/attention.py` 现在会在
+import 时读 `shared_memory_per_block_optin`，< 140KB 自动切小 tile（`_SMALL_SMEM`）：
+
+| launch 点 | H100 配置 | 小 SMEM 配置 |
+|---|---|---|
+| fwd ×2 | D≥512: (BQ64,BKV32,s2) | D≥512: (32,16,s1)；D<512: (64,32,s1) |
+| bwd dq | D≥512: (32,64,w8) | D≥512: (16,16,w4)；D<512: (32,32,w4) |
+| bwd dkv | D≥512: (BKV16,BQ64,s2) | D≥512: (BKV16,BQ16,s1)；D<512: (BKV16,BQ32,s1) |
+
+H100/H200 等大 SMEM 卡不受影响（沿用上游配置）。
+
+## 三个集成要点（踩过的坑）
+
+1. **包名冲突**：本仓库包目录叫 `flash_attn`，与 pip 的 flash-attn wheel 撞名。
+   ms-swift 启动时先 import 真 flash-attn 并缓存 → 直接 `import flash_attn` 会被
+   遮蔽。`integrations/ms_swift/triton_attn_patch.py` 用 importlib 以私有名
+   `_gtfa` 加载本仓库，与 wheel 共存。
+2. **attention_mask 传 None**：kernel 自建 causal/滑窗 mask；HF 的 4D mask 会触发
+   适配器的 multimodal 守卫。纯文本 + **右 padding** 时传 None 是安全的（pad 在
+   真实 token 之后，causal 天然屏蔽；pad 位无 loss）。**左 padding 勿用**。
+3. **别用短输入冒烟**：N<16 时 `tl.dot` 直接编译错误；验证用 ≥512 token 的输入。
+
+## 正确性验证方法（换 kernel 必做）
+
+- 单层级：真实激活上逐层对比 kernel vs SDPA，\|Δ\| 应在 bf16 噪声（~0.1）内。
+- **不要**用全模型末层 logits 判断 —— 48 层 bf16 误差累积可到 \|Δ\|≈3，是正常现象。
+- 训练级：同 seed 跑若干步，**step-1 loss 必须一致**（权重未更新前 loss 只由
+  forward 决定）；之后的逐步差异是混沌放大，看轨迹量级即可。

--- a/flash_attn/attention.py
+++ b/flash_attn/attention.py
@@ -3,6 +3,15 @@ import triton
 import triton.language as tl
 import math
 
+# Small-SMEM GPUs (e.g. RTX PRO 6000 Blackwell: 99KB/block vs H100's 228KB) can't
+# hold the H100-tuned tile configs. Detect once and shrink blocks at every launch
+# site — same math, smaller tiles.
+try:
+    _SMEM_LIM = torch.cuda.get_device_properties(0).shared_memory_per_block_optin
+except Exception:
+    _SMEM_LIM = 1 << 20
+_SMALL_SMEM = _SMEM_LIM < 140 * 1024
+
 
 # =====================================================================
 # PyTorch reference: scaled dot-product attention
@@ -621,9 +630,9 @@ def attention_flash_gqa(q, k, v, causal=False, slide_size=0,
     #   D<256:                        (BQ=128, BKV=64) — same as D=256
     # num_warps=8 for D>=256 (large tiles need many warps to hide latency).
     if BLOCK_Q is None:
-        BLOCK_Q = 64 if D >= 512 else 128
+        BLOCK_Q = (32 if D >= 512 else 64) if _SMALL_SMEM else (64 if D >= 512 else 128)
     if BLOCK_KV is None:
-        BLOCK_KV = 32 if D >= 512 else 64
+        BLOCK_KV = (16 if D >= 512 else 32) if _SMALL_SMEM else (32 if D >= 512 else 64)
     if BLOCK_D is None:
         BLOCK_D = D  # no D-tiling: single tl.dot per KV tile
     if num_warps is None:
@@ -1567,11 +1576,15 @@ class FlashAttnGQAFunction(torch.autograd.Function):
         if slide_size > 0 and slide_size >= N:
             slide_size = 0
 
-        BLOCK_Q = 64 if D >= 512 else 128
-        BLOCK_KV = 32 if D >= 512 else 64
+        if _SMALL_SMEM:
+            BLOCK_Q = 32 if D >= 512 else 64
+            BLOCK_KV = 16 if D >= 512 else 32
+        else:
+            BLOCK_Q = 64 if D >= 512 else 128
+            BLOCK_KV = 32 if D >= 512 else 64
         BLOCK_D = D
         num_warps = 8 if D >= 256 else 4
-        num_stages = 2
+        num_stages = 1 if _SMALL_SMEM else 2
         BLOCK_Q = min(BLOCK_Q, triton.next_power_of_2(N))
         BLOCK_KV = min(BLOCK_KV, triton.next_power_of_2(N))
         grid = (triton.cdiv(N, BLOCK_Q), B * H_Q)
@@ -1636,7 +1649,9 @@ class FlashAttnGQAFunction(torch.autograd.Function):
         # D-specific tuning (sweeps in context/baseline.md):
         #   D=512: (BQ=32, BKV=64, w=8)  — register-constrained, need 8 warps
         #   D=256: (BQ=64, BKV=64, w=4)  — more headroom, larger BQ + fewer warps win
-        if D >= 512:
+        if _SMALL_SMEM:
+            BLOCK_Q_BW, BLOCK_KV_BW, num_warps_bw = (16, 16, 4) if D >= 512 else (32, 32, 4)
+        elif D >= 512:
             BLOCK_Q_BW, BLOCK_KV_BW, num_warps_bw = 32, 64, 8
         else:
             BLOCK_Q_BW, BLOCK_KV_BW, num_warps_bw = 64, 64, 4
@@ -1677,7 +1692,12 @@ class FlashAttnGQAFunction(torch.autograd.Function):
         #
         # The old split path (_flash_attn_gqa_bwd_dkv_kernel with expand+reduce)
         # is kept in the source for reference but no longer on the hot path.
-        if D >= 512:
+        if _SMALL_SMEM:
+            # 99KB budget: fp32 dk/dv accumulators dominate (BKV*D*4 each);
+            # keep BKV=16 and shrink BQ so q/do tiles fit alongside.
+            BLOCK_KV_DKV, BLOCK_Q_DKV, num_warps_dkv = (16, 16, 4) if D >= 512 else (16, 32, 4)
+            num_stages_dkv = 1
+        elif D >= 512:
             # Pack-GQA sweep @ N=4K Gemma4 (H_Q=32,H_KV=4): (BKV=16,BQ=64,w=4)
             # wins 9.36ms vs old (32,16,8)=13.13ms (-29%); BKV=16 halves
             # dk_acc/dv_acc shmem (32KB×2 vs 64KB×2), freeing budget for BQ=64

--- a/integrations/ms_swift/triton_attn_patch.py
+++ b/integrations/ms_swift/triton_attn_patch.py
@@ -1,0 +1,65 @@
+"""ms-swift integration for gemma-triton-flash-attn (use via --custom_register_path).
+
+Routes ALL attention (Gemma-4's 40 sliding D=256 layers AND 8 global D=512
+layers) through this repo's Triton flash kernel while swift stays on
+`--attn_impl sdpa`. Anything the kernel doesn't support (dropout>0, softcap,
+decode-length N) falls back to stock SDPA transparently.
+
+Why not `pip install` + plain import: this repo's package dir is named
+`flash_attn`, which collides with the flash-attn wheel that ms-swift imports
+first — a plain `import flash_attn` then resolves to the wheel and this repo is
+shadowed. We therefore load the package under a private module name with
+importlib, anchored to this file's location (works from any clone path).
+
+Usage:
+    swift rlhf ... \
+        --attn_impl sdpa \
+        --custom_register_path /path/to/repo/integrations/ms_swift/triton_attn_patch.py
+
+Padding note: the kernel builds its own causal/sliding mask and ignores HF's
+attention_mask (we pass None). This is safe for right-padded training batches:
+padding sits after real tokens, so causal masking already hides it from real
+queries, and pad positions carry no loss. Do NOT use with left padding.
+"""
+import importlib.util
+import pathlib
+import sys
+
+_REPO = str(pathlib.Path(__file__).resolve().parents[2])
+
+# Load the repo package under a private name to dodge the flash-attn wheel.
+_spec = importlib.util.spec_from_file_location(
+    '_gtfa', f'{_REPO}/flash_attn/__init__.py',
+    submodule_search_locations=[f'{_REPO}/flash_attn'])
+_gtfa = importlib.util.module_from_spec(_spec)
+sys.modules['_gtfa'] = _gtfa
+_spec.loader.exec_module(_gtfa)
+triton_gqa_attention = _gtfa.triton_gqa_attention
+
+from transformers.integrations.sdpa_attention import sdpa_attention_forward  # noqa: E402
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS  # noqa: E402
+
+_HITS = [0]
+
+
+def _triton_sdpa(module, query, key, value, attention_mask, **kwargs):
+    # kernel wants tl.dot dims >=16; generation/decode short-N goes to SDPA.
+    if query.shape[-2] >= 64 and kwargs.get('dropout', 0.0) == 0.0 \
+            and kwargs.get('softcap') is None:
+        try:
+            out = triton_gqa_attention(module, query, key, value, None, **kwargs)
+            _HITS[0] += 1
+            if _HITS[0] == 1:
+                print(f'[triton_attn_patch] ENGAGED: D={query.shape[-1]} '
+                      f'N={query.shape[-2]} q{tuple(query.shape)} '
+                      f'slide={kwargs.get("sliding_window")}', flush=True)
+            return out
+        except Exception as e:
+            if _HITS[0] == 0:
+                print(f'[triton_attn_patch] fallback->SDPA: {str(e)[:100]}', flush=True)
+    return sdpa_attention_forward(module, query, key, value, attention_mask, **kwargs)
+
+
+ALL_ATTENTION_FUNCTIONS['sdpa'] = _triton_sdpa
+print('[triton_attn_patch] sdpa overridden -> gemma-triton-flash-attn '
+      '(both sliding D=256 and global D=512 layers)', flush=True)

--- a/skills/2026-07-10_small-smem-workstation-gpu.md
+++ b/skills/2026-07-10_small-smem-workstation-gpu.md
@@ -1,0 +1,43 @@
+# 小 Shared Memory GPU（工作站 Blackwell 99KB）适配：_SMALL_SMEM 缩块方案
+
+> 适用场景：在 shared memory/block < 140KB 的 GPU（如 RTX PRO 6000 Blackwell Server / RTX 5090 工作站卡，SM120，99KB）上跑本 kernel。H100 调优的 tile 配置会直接 `OutOfResources: shared memory`。
+
+---
+
+## 问题
+
+- H100 有 **228KB/SM** shared memory（optin），本仓库所有 block config 按它调优。
+- 工作站 Blackwell（SM120）只有 **99KB/block optin**（`shared_memory_per_block_optin=101376`）。
+- D=512 fwd 默认 (BQ=64, BKV=32, stages=2) 需要 **147456B (144KB)** → 编译期 OutOfResources。
+- 只调 `num_stages` 没用：SMEM 大头是 Q/K/V tile 本体（(BQ+2·BKV)×D×2B），不是 pipeline buffer。
+
+## 方案：`_SMALL_SMEM` 自动检测 + 四处 launch 缩块
+
+模块加载时读 `torch.cuda.get_device_properties(0).shared_memory_per_block_optin`，< 140KB 即启用小块配置（数学不变，只缩 tile）：
+
+| launch 点 | H100 配置 | 小 SMEM 配置 |
+|---|---|---|
+| fwd (`attention_flash_gqa` + `FlashAttnGQAFunction.forward`) | D≥512: (BQ64, BKV32, s2) / D<512: (128, 64, s2) | D≥512: **(32, 16, s1)** / D<512: **(64, 32, s1)** |
+| bwd dq | D≥512: (32, 64, w8) / D<512: (64, 64, w4) | D≥512: **(16, 16, w4)** / D<512: **(32, 32, w4)** |
+| bwd dkv (packed) | D≥512: (BKV16, BQ64, w4, s2) / D<512: grid 启发式 | D≥512: **(BKV16, BQ16, w4, s1)** / D<512: **(BKV16, BQ32, w4, s1)** |
+
+SMEM 估算口径：fwd ≈ (BQ + 2·BKV)×D×2B + ~16KB 杂项；dkv 的 fp32 dk/dv accumulator 是大头（BKV×D×4B ×2），所以 dkv 优先压 BKV。tl.dot 各维 ≥16 是下限。
+
+## 实测（RTX PRO 6000 Blackwell，bf16，B=2 Hq=16 Hkv=8 N=4096）
+
+| 形状 | 正确性 (vs SDPA) | fwd+bwd 提速 |
+|---|---|---|
+| D=512 full causal | fwd \|Δ\|max=0.008，dq/dk/dv \|Δ\|max ≤0.031 | **2.6×** (30.9ms vs 79.1ms) |
+| D=256 SWA slide=1024 | 同上 | **9.2×** (4.2ms vs 39.1ms) |
+
+E2E（gemma-4-12B DPO，LoRA r64，max_len 8192，grad ckpt，同数据同 seed 逐 step 对齐 34 步）：**1.47×**（SDPA 11m51s vs Triton 8m03s，分段稳定 1.41-1.51×）；step-1 loss 与 SDPA 精确一致（0.8197）。与 NeMo Automodel 在 Gemma4-31B 报的 E2E 1.4-1.5× 相符。
+
+## 额外收益：根治 SDPA math-path OOM
+
+SDPA 对 D=512 无 fused kernel → math path 物化 **fp32 N×N**（N=8192 时 2×16×8192²×4B = **8.0GiB** 瞬时尖峰），在 95GB 卡上顶爆 88GB 基线。本 kernel flash 式 O(N)，尖峰结构性消除。
+
+## 踩坑
+
+1. **短输入测不出**：N < 16 时 `tl.dot` K 维不足直接 CompilationError（`Input shapes should have M>=1, N>=1 and K>=16`）——别用 10-token prompt 冒烟。
+2. **包名冲突**：仓库包目录叫 `flash_attn`，与 pip 的 flash-attn 2.8.3 撞名。训练框架（ms-swift）会先 import 真包并缓存 → 本仓库被遮蔽。解法：`importlib.util.spec_from_file_location` 用私有模块名加载（见 `docs/ms-swift-integration.md`）。
+3. **多层 bf16 累积 ≠ kernel 错误**：48 层全模型 forward 换 kernel 后末层 logits |Δ| 可到 ~3（误差逐层放大），单层对比 |Δ| ~0.1 才是正确的判据；训练判据用 step-1 loss 是否一致。

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -12,6 +12,7 @@
 | `2026-04-17_q-split-dkv.md` | dKV pack-GQA kernel Q_SPLIT + atomic_add 回收 SM occupancy；gate 在 raw_grid < 256 才开，目标 2-wave on 132 SMs |
 | `2026-04-17_grid-gate-over-n-gate.md` | Block-config gate 应该基于 raw_grid 不是 N 单维；H_KV/B 同样影响 grid，误推广旧结论就会埋雷 (Config A 短 N BKV=32 碎片 4 月误用案例) |
 | `2026-04-17_alloc-not-bottleneck.md` | training bwd 的 alloc 只占 3-5%（caching allocator 很快），别优化；autograd.Function 框架 80μs CPU-exclusive 才是 short-N 剩余瓶颈 |
+| `2026-07-10_small-smem-workstation-gpu.md` | 99KB SMEM 工作站卡（Blackwell SM120）适配：`_SMALL_SMEM` 自动缩块四处 launch；实测 2.6×/9.2×、根治 SDPA math-path 8GB OOM；含 ms-swift 集成踩坑（flash_attn 包名冲突） |
 
 ---
 


### PR DESCRIPTION
Workstation Blackwell cards (RTX PRO 6000 / RTX 5090, SM120) only have 99KB shared memory per block (shared_memory_per_block_optin=101376) vs H100's 228KB. The stock D=512 forward config needs 144KB and fails to compile with OutOfResources; the D=256 and backward configs exceed the budget too.

Changes:
- attention.py: detect shared_memory_per_block_optin at import; when <140KB, use shrunken tile configs at all 4 launch sites (fwd x2, bwd dq, bwd dkv). Same math, smaller tiles. H100+ is unaffected.
- integrations/ms_swift/triton_attn_patch.py: one-flag ms-swift integration (--custom_register_path). Loads the package under a private module name to avoid the name collision with the pip flash-attn wheel that training frameworks import first.
- docs/ms-swift-integration.md: usage guide, pitfalls, verification method.
- skills/2026-07-10_small-smem-workstation-gpu.md: tuning notes in the established skills/ format.

Measured on RTX PRO 6000 Blackwell (bf16, gemma-4-12B shapes, B=2 Hq=16 Hkv=8 N=4096, fwd+bwd): D=512 full causal 2.6x vs SDPA, D=256 SWA(1024) 9.2x. Correctness: fwd |d|<=0.008, grads |d|<=0.031 vs SDPA; DPO training step-1 loss identical to SDPA. End-to-end DPO training (ms-swift, LoRA r64, max_length 8192, step-aligned over 34 steps): 1.47x. Also eliminates the fp32 NxN materialization spike (8GiB at N=8192) SDPA's math path incurs on D=512 layers.