### PR TITLE
doc-mask + sm100: packed-document isolation for batched kernels + B300 (sm_103a) support

### DIFF
--- a/benchmarks/bench_doc_regime.py
+++ b/benchmarks/bench_doc_regime.py
@@ -1,0 +1,104 @@
+"""Doc-clamped (packed multi-document) regime benchmark for B300.
+
+Reproduces the e2e training regime: 32K packed sequence of ~154-token docs,
+doc bounds from position_ids. Reports per-kernel time (fwd / dQ / dKV) via
+torch.profiler for both gemma4 geometries, plus numerics vs an fp32
+block-diagonal reference at small S.
+
+Env knobs (GTFA_DQ_*, GTFA_DKV_*) are honored by the patched attention.py.
+"""
+
+import math
+import os
+
+import torch
+import torch.nn.functional as F
+from flash_attn.attention import doc_bounds_from_position_ids, flash_attn_gqa_train
+
+DEV, DTYPE = "cuda", torch.bfloat16
+
+
+def packed_position_ids(S, doc_len=154, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    lens = []
+    total = 0
+    while total < S:
+        n = int(torch.randint(doc_len // 2, doc_len * 2, (1,), generator=g))
+        n = min(n, S - total)
+        lens.append(n)
+        total += n
+    pos = torch.cat([torch.arange(n) for n in lens])
+    return pos[None].to(DEV), lens
+
+
+def numerics_check(Hq, Hkv, D, W, S=4096):
+    pos, lens = packed_position_ids(S)
+    lo, hi = doc_bounds_from_position_ids(pos)
+    torch.manual_seed(0)
+    q = torch.randn(1, Hq, S, D, device=DEV, dtype=DTYPE, requires_grad=True)
+    k = torch.randn(1, Hkv, S, D, device=DEV, dtype=DTYPE, requires_grad=True)
+    v = torch.randn(1, Hkv, S, D, device=DEV, dtype=DTYPE, requires_grad=True)
+    dout = torch.randn(1, Hq, S, D, device=DEV, dtype=DTYPE)
+    out = flash_attn_gqa_train(q, k, v, causal=True, slide_size=W, doc_lo=lo, doc_hi_excl=hi)
+    gq, gk, gv = torch.autograd.grad(out, (q, k, v), dout)
+
+    n = Hq // Hkv
+    qf = q.detach().float().requires_grad_(True)
+    kf = k.detach().float().requires_grad_(True)
+    vf = v.detach().float().requires_grad_(True)
+    sc = qf @ kf.repeat_interleave(n, 1).transpose(-1, -2) / math.sqrt(D)
+    qi = torch.arange(S, device=DEV)[:, None]
+    ki = torch.arange(S, device=DEV)[None, :]
+    keep = (ki <= qi) & (lo[0][:, None] <= ki)
+    if W:
+        keep &= (qi - ki) < W
+    ref = F.softmax(sc.masked_fill(~keep, float("-inf")), -1) @ vf.repeat_interleave(n, 1)
+    rq, rk, rv = torch.autograd.grad(ref, (qf, kf, vf), dout.float())
+    for nm, g_, r in (("out", out, ref), ("dq", gq, rq), ("dk", gk, rk), ("dv", gv, rv)):
+        rel = (g_.float() - r).abs().max() / r.abs().max().clamp_min(1e-6)
+        print(f"    numerics {nm}: rel-to-max {rel.item():.2e}")
+
+
+def profile_case(name, Hq, Hkv, D, W, S=32768):
+    pos, lens = packed_position_ids(S)
+    lo, hi = doc_bounds_from_position_ids(pos)
+    torch.manual_seed(0)
+    q = torch.randn(1, Hq, S, D, device=DEV, dtype=DTYPE)
+    k = torch.randn(1, Hkv, S, D, device=DEV, dtype=DTYPE)
+    v = torch.randn(1, Hkv, S, D, device=DEV, dtype=DTYPE)
+    dout = torch.randn_like(q)
+
+    def run():
+        q_, k_, v_ = (t.detach().requires_grad_(True) for t in (q, k, v))
+        o = flash_attn_gqa_train(q_, k_, v_, causal=True, slide_size=W, doc_lo=lo, doc_hi_excl=hi)
+        torch.autograd.grad(o, (q_, k_, v_), dout)
+
+    for _ in range(3):
+        run()
+    torch.cuda.synchronize()
+    from torch.profiler import ProfilerActivity, profile
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        for _ in range(5):
+            run()
+        torch.cuda.synchronize()
+    agg = {}
+    for e in prof.key_averages():
+        if "_flash_attn" in e.key:
+            agg[e.key.split("<")[0]] = e.device_time_total / 1e3 / 5
+    total = sum(agg.values())
+    docs = len(lens)
+    print(f"  {name} S={S} docs={docs}: total {total:8.2f} ms/iter | " +
+          " | ".join(f"{k.replace('_flash_attn_gqa_', '')}: {v:.2f}" for k, v in sorted(agg.items())))
+
+
+if __name__ == "__main__":
+    print(f"GTFA env: DQ={os.getenv('GTFA_DQ_BQ','-')}/{os.getenv('GTFA_DQ_BKV','-')}/w{os.getenv('GTFA_DQ_W','-')} "
+          f"DKV={os.getenv('GTFA_DKV_BKV','-')}/{os.getenv('GTFA_DKV_BQ','-')}/w{os.getenv('GTFA_DKV_W','-')}/s{os.getenv('GTFA_DKV_ST','-')}")
+    if os.getenv("GTFA_NUMERICS") == "1":
+        print("  [sliding numerics]")
+        numerics_check(32, 16, 256, 1024)
+        print("  [global numerics]")
+        numerics_check(32, 4, 512, 0)
+    profile_case("sliding D256 W1024", 32, 16, 256, 1024)
+    profile_case("global  D512 causal", 32, 4, 512, 0)

--- a/benchmarks/sweep_b300_d512_bwd.sh
+++ b/benchmarks/sweep_b300_d512_bwd.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# B300 (sm103) sweep for D=512 backward kernels via GTFA_* env overrides.
+# Fresh process per config to avoid CUDA-context poisoning from bad configs.
+set -u
+PY=${PY:-python}
+REPO=${REPO:-/tmp/gemma-triton-flash-attn}
+
+probe() {
+  local tag="$1"; shift
+  env "$@" PYTHONPATH=$REPO CUDA_VISIBLE_DEVICES=0 $PY - <<'EOF' 2>/dev/null | tail -1 | sed "s|^|$tag |"
+import torch, time
+from flash_attn.attention import flash_attn_gqa_train, attention_flash_gqa
+
+S, Hq, Hkv, D = 8192, 32, 4, 512
+q = torch.randn(1, Hq, S, D, device="cuda", dtype=torch.bfloat16)
+k = torch.randn(1, Hkv, S, D, device="cuda", dtype=torch.bfloat16)
+v = torch.randn(1, Hkv, S, D, device="cuda", dtype=torch.bfloat16)
+dout = torch.randn_like(q)
+
+def run():
+    q_, k_, v_ = (t.detach().requires_grad_(True) for t in (q, k, v))
+    out = flash_attn_gqa_train(q_, k_, v_, causal=True, slide_size=0)
+    torch.autograd.grad(out, (q_, k_, v_), dout)
+
+def fwd():
+    with torch.no_grad():
+        attention_flash_gqa(q, k, v, causal=True, slide_size=0)
+
+def bench(fn, n=10):
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        fn()
+    torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / n * 1e3
+
+try:
+    f = bench(fwd)
+    fb = bench(run)
+    fl = 3.5 * 4.0 * Hq * (S * (S + 1) // 2) * D
+    print(f"fwd {f:8.2f} ms | fwd+bwd {fb:8.2f} ms | bwd {fb-f:8.2f} ms | {fl/(fb/1e3)/1e12:6.1f} TFLOPS")
+except Exception as e:
+    print(f"FAILED {type(e).__name__}: {str(e)[:90]}")
+EOF
+}
+
+echo "--- baseline (branch defaults) ---"
+probe "default              "
+
+echo "--- dQ sweep (dKV default) ---"
+probe "dQ 32/32/8/2         " GTFA_DQ_BQ=32 GTFA_DQ_BKV=32 GTFA_DQ_W=8
+probe "dQ 64/32/8/2         " GTFA_DQ_BQ=64 GTFA_DQ_BKV=32 GTFA_DQ_W=8
+probe "dQ 32/64/4/2         " GTFA_DQ_W=4
+probe "dQ 32/64/8/1         " GTFA_DQ_ST=1
+probe "dQ 16/64/8/2         " GTFA_DQ_BQ=16
+probe "dQ 64/64/8/2         " GTFA_DQ_BQ=64
+
+echo "--- dKV sweep (dQ default) ---"
+probe "dKV 16/32/4/2        " GTFA_DKV_BQ=32
+probe "dKV 32/32/4/2        " GTFA_DKV_BKV=32 GTFA_DKV_BQ=32
+probe "dKV 32/32/8/2        " GTFA_DKV_BKV=32 GTFA_DKV_BQ=32 GTFA_DKV_W=8
+probe "dKV 16/64/8/2        " GTFA_DKV_W=8
+probe "dKV 8/64/4/2         " GTFA_DKV_BKV=8
+probe "dKV 16/128/4/2       " GTFA_DKV_BQ=128
+probe "dKV 16/64/4/1        " GTFA_DKV_ST=1

--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -38,6 +38,7 @@ from .attention import (
     # Primary Triton kernels (public API)
     attention_flash_gqa,
     flash_attn_gqa_train,
+    doc_bounds_from_position_ids,
     FlashAttnGQAFunction,
     # Reference implementations
     attention_gqa_ref,
@@ -59,6 +60,7 @@ __version__ = "0.1.0"
 __all__ = [
     "attention_flash_gqa",
     "flash_attn_gqa_train",
+    "doc_bounds_from_position_ids",
     "FlashAttnGQAFunction",
     "attention_gqa_ref",
     "attention_swa_ref",

--- a/flash_attn/attention.py
+++ b/flash_attn/attention.py
@@ -273,6 +273,13 @@ def _flash_attn_gqa_kernel(
     GroupHi_ptr,
     stride_gb, stride_gn,
     HAS_GROUP_IDS: tl.constexpr,
+    # Packed-document isolation (text packing). DocLo[b, n] = start index of
+    # token n's document; kv < DocLo(q) is masked so causal attention never
+    # crosses a packed-document boundary (FA varlen cu_seqlens equivalent).
+    # Constant-folded away when HAS_DOC_MASK=False.
+    DocLo_ptr,
+    stride_docb, stride_docn,
+    HAS_DOC_MASK: tl.constexpr,
 ):
     # Grid: (cdiv(SEQ_LEN, BLOCK_Q), B * N_Q_HEADS)
     q_block_idx = tl.program_id(0)
@@ -309,6 +316,12 @@ def _flash_attn_gqa_kernel(
         block_img_lo = tl.min(q_group_lo, axis=0)
         block_img_hi = tl.max(q_group_hi, axis=0)
 
+    # Per-token document start for packed-doc isolation.
+    if HAS_DOC_MASK:
+        dlo_base = DocLo_ptr + b_idx * stride_docb
+        q_doc_lo = tl.load(dlo_base + q_offsets * stride_docn, mask=q_mask, other=0)
+        block_doc_lo = tl.min(q_doc_lo, axis=0)
+
     # Determine KV iteration range.
     if IS_CAUSAL:
         kv_end = (q_block_idx + 1) * BLOCK_Q
@@ -328,6 +341,12 @@ def _flash_attn_gqa_kernel(
         kv_loop_start = tl.minimum(kv_loop_start, (block_img_lo // BLOCK_KV) * BLOCK_KV)
         kv_end = tl.maximum(kv_end, block_img_hi)
 
+    # No token attends before its document start: skip whole KV tiles below
+    # the block's earliest doc start. This is where packed short docs keep
+    # their FLOPs advantage (compute scales with doc length, not SEQ_LEN).
+    if HAS_DOC_MASK and IS_CAUSAL:
+        kv_loop_start = tl.maximum(kv_loop_start, (block_doc_lo // BLOCK_KV) * BLOCK_KV)
+
     LOG2E: tl.constexpr = 1.4426950408889634
     scale_log2e = scale * LOG2E
 
@@ -343,7 +362,7 @@ def _flash_attn_gqa_kernel(
     # When HAS_GROUP_IDS, every tile may need an OR-mask check, so the unmasked
     # phase optimization is unsafe — disable it.
     USE_SPLIT: tl.constexpr = (HEAD_DIM < 512)
-    if IS_CAUSAL and SLIDE_SIZE == 0 and USE_SPLIT and not HAS_GROUP_IDS:
+    if IS_CAUSAL and SLIDE_SIZE == 0 and USE_SPLIT and not HAS_GROUP_IDS and not HAS_DOC_MASK:
         kv_end_unmasked = (q_block_idx * BLOCK_Q) // BLOCK_KV * BLOCK_KV
     else:
         kv_end_unmasked = kv_loop_start  # skip unmasked phase
@@ -400,13 +419,17 @@ def _flash_attn_gqa_kernel(
             bidir = (q_group_ids[:, None] == kv_group_ids[None, :]) & \
                     (q_group_ids[:, None] >= 0) & kv_mask[None, :]
             valid = valid | bidir
+        if HAS_DOC_MASK:
+            valid = valid & (kv_offsets[None, :] >= q_doc_lo[:, None])
         scores = tl.where(valid, scores, -float("inf"))
 
         block_max = tl.max(scores, axis=1)
         new_max = tl.maximum(m_i, block_max)
         # SWA may produce all-masked rows (no key visible); HAS_GROUP_IDS
-        # implies SWA path and inherits the same NaN-clamp safeguard.
-        if SLIDE_SIZE > 0:
+        # implies SWA path and inherits the same NaN-clamp safeguard. Doc-mask
+        # KV tiles that lie entirely before a row's document start are
+        # all-masked too, so they need the same clamp.
+        if SLIDE_SIZE > 0 or HAS_DOC_MASK:
             safe_new = tl.maximum(new_max, -1e20)
             alpha = tl.math.exp2(tl.maximum(m_i, -1e20) - safe_new)
             p = tl.math.exp2(scores - safe_new[:, None])
@@ -620,8 +643,13 @@ def attention_flash_gqa(q, k, v, causal=False, slide_size=0,
     #   D=256 (Gemma4 sliding attn):  (BQ=128, BKV=64) — more headroom, larger blocks win
     #   D<256:                        (BQ=128, BKV=64) — same as D=256
     # num_warps=8 for D>=256 (large tiles need many warps to hide latency).
+    # sm_100+ (B200/B300, 227KB smem/SM): the H100-tuned tiles overflow shared
+    # memory (~274KB) and BQ=64@D=512 additionally hits a misaligned-address
+    # miscompile on sm_103a; halve BLOCK_Q (sweep 2026-07-09 on B300 sm_103a:
+    # D=512 (32,32) 2.73ms, D=256 (64,64) 0.25ms @ N=4096).
+    _sm100 = torch.cuda.get_device_capability()[0] >= 10
     if BLOCK_Q is None:
-        BLOCK_Q = 64 if D >= 512 else 128
+        BLOCK_Q = (32 if _sm100 else 64) if D >= 512 else (64 if _sm100 else 128)
     if BLOCK_KV is None:
         BLOCK_KV = 32 if D >= 512 else 64
     if BLOCK_D is None:
@@ -665,6 +693,8 @@ def attention_flash_gqa(q, k, v, causal=False, slide_size=0,
         GroupIds_ptr=group_ids, GroupLo_ptr=group_lo, GroupHi_ptr=group_hi_excl,
         stride_gb=g_strides[0], stride_gn=g_strides[1],
         HAS_GROUP_IDS=has_group_ids,
+        DocLo_ptr=None, stride_docb=0, stride_docn=0,
+        HAS_DOC_MASK=False,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -776,6 +806,10 @@ def _flash_attn_gqa_bwd_dq_kernel(
     GroupHi_ptr,
     stride_gb, stride_gn,
     HAS_GROUP_IDS: tl.constexpr,
+    # Packed-document isolation (mirror of fwd kernel).
+    DocLo_ptr,
+    stride_docb, stride_docn,
+    HAS_DOC_MASK: tl.constexpr,
 ):
     q_block_idx = tl.program_id(0)
     bh_idx = tl.program_id(1)
@@ -841,6 +875,14 @@ def _flash_attn_gqa_bwd_dq_kernel(
         kv_loop_start = tl.minimum(kv_loop_start, (block_img_lo // BLOCK_KV) * BLOCK_KV)
         kv_end = tl.maximum(kv_end, block_img_hi)
 
+    # Packed-doc isolation: per-token doc start + KV tile skip (mirror of fwd).
+    if HAS_DOC_MASK:
+        dlo_base = DocLo_ptr + b_idx * stride_docb
+        q_doc_lo = tl.load(dlo_base + q_offsets * stride_docn, mask=q_mask, other=0)
+        if IS_CAUSAL:
+            block_doc_lo = tl.min(q_doc_lo, axis=0)
+            kv_loop_start = tl.maximum(kv_loop_start, (block_doc_lo // BLOCK_KV) * BLOCK_KV)
+
     dq_acc = tl.zeros([BLOCK_Q, HEAD_DIM], dtype=tl.float32)
 
     # Convert LSE to log2 domain once so we can use tl.math.exp2 inside the loop.
@@ -873,6 +915,8 @@ def _flash_attn_gqa_bwd_dq_kernel(
             bidir = (q_group_ids[:, None] == kv_group_ids[None, :]) & \
                     (q_group_ids[:, None] >= 0) & kv_mask[None, :]
             valid = valid | bidir
+        if HAS_DOC_MASK:
+            valid = valid & (kv_offsets[None, :] >= q_doc_lo[:, None])
         scores = tl.where(valid, scores, -float("inf"))
         p = tl.math.exp2(scores - lse_log2[:, None])
 
@@ -1196,6 +1240,12 @@ def _flash_attn_gqa_bwd_dkv_packed_kernel(
     GroupHi_ptr,
     stride_gb, stride_gn,
     HAS_GROUP_IDS: tl.constexpr,
+    # Packed-document isolation. KV-major iteration needs the KV side of the
+    # bound: DocHi[b, n] = end (exclusive) of token n's document; q >= DocHi(kv)
+    # is masked, and the Q loop is clamped to the tile's furthest doc end.
+    DocHi_ptr,
+    stride_docb, stride_docn,
+    HAS_DOC_MASK: tl.constexpr,
 ):
     # Grid: (cdiv(SEQ_LEN, BLOCK_KV), B * N_KV_HEADS, Q_SPLITS)
     kv_block_idx = tl.program_id(0)
@@ -1261,6 +1311,13 @@ def _flash_attn_gqa_bwd_dkv_packed_kernel(
         q_loop_end = tl.maximum(q_loop_end, block_img_hi)
         # q_loop_end may exceed SEQ_LEN at the tail; mask handles it inside loop.
 
+    # Packed-doc isolation: no query outside this KV tile's documents can
+    # attend to it, so the Q loop stops at the tile's furthest doc end.
+    if HAS_DOC_MASK:
+        dhi_base = DocHi_ptr + b_idx * stride_docb
+        kv_doc_hi = tl.load(dhi_base + kv_offsets * stride_docn, mask=kv_mask, other=0)
+        q_loop_end = tl.minimum(q_loop_end, tl.max(kv_doc_hi, axis=0))
+
     # Q-split: each of Q_SPLITS programs handles a disjoint slice of Q blocks.
     # Activated when raw grid << 132 SMs (e.g. H_KV=1 short N). Atomic_add on
     # dK/dV (caller pre-zeroed) replaces direct store.
@@ -1313,6 +1370,8 @@ def _flash_attn_gqa_bwd_dkv_packed_kernel(
                         (q_group_ids[:, None] >= 0) & \
                         kv_mask[None, :] & q_mask_local[:, None]
                 valid = valid | bidir
+            if HAS_DOC_MASK:
+                valid = valid & (q_offsets[:, None] < kv_doc_hi[None, :])
             scores = tl.where(valid, scores, -float("inf"))
             p = tl.math.exp2(scores - lse_log2[:, None])
 
@@ -1557,7 +1616,8 @@ def _flash_attn_gqa_bwd_dk_only_kernel(
 
 class FlashAttnGQAFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, q, k, v, causal, slide_size, group_ids, group_lo, group_hi_excl):
+    def forward(ctx, q, k, v, causal, slide_size, group_ids, group_lo, group_hi_excl,
+                doc_lo, doc_hi_excl):
         B, H_Q, N, D = q.shape
         _, H_KV, _, _ = k.shape
         output = torch.empty_like(q)
@@ -1567,7 +1627,9 @@ class FlashAttnGQAFunction(torch.autograd.Function):
         if slide_size > 0 and slide_size >= N:
             slide_size = 0
 
-        BLOCK_Q = 64 if D >= 512 else 128
+        # sm_100+ tile downsizing — see attention_flash_gqa for the rationale.
+        _sm100 = torch.cuda.get_device_capability()[0] >= 10
+        BLOCK_Q = (32 if _sm100 else 64) if D >= 512 else (64 if _sm100 else 128)
         BLOCK_KV = 32 if D >= 512 else 64
         BLOCK_D = D
         num_warps = 8 if D >= 256 else 4
@@ -1582,6 +1644,14 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             g_strides = (group_ids.stride(0), group_ids.stride(1))
         else:
             g_strides = (0, 0)
+
+        has_doc_mask = doc_lo is not None
+        if has_doc_mask:
+            assert doc_hi_excl is not None, "doc_lo requires doc_hi_excl"
+            assert causal, "doc masking assumes causal attention (packed docs)"
+            doc_strides = (doc_lo.stride(0), doc_lo.stride(1))
+        else:
+            doc_strides = (0, 0)
 
         _flash_attn_gqa_kernel[grid](
             q, k, v, output,
@@ -1599,24 +1669,33 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             GroupIds_ptr=group_ids, GroupLo_ptr=group_lo, GroupHi_ptr=group_hi_excl,
             stride_gb=g_strides[0], stride_gn=g_strides[1],
             HAS_GROUP_IDS=has_group_ids,
+            DocLo_ptr=doc_lo, stride_docb=doc_strides[0], stride_docn=doc_strides[1],
+            HAS_DOC_MASK=has_doc_mask,
             num_warps=num_warps, num_stages=num_stages,
         )
 
         # save_for_backward supports None entries (kept as None in saved_tensors).
-        ctx.save_for_backward(q, k, v, output, lse, group_ids, group_lo, group_hi_excl)
+        ctx.save_for_backward(q, k, v, output, lse, group_ids, group_lo, group_hi_excl,
+                              doc_lo, doc_hi_excl)
         ctx.causal = causal
         ctx.slide_size = slide_size
         ctx.has_group_ids = has_group_ids
+        ctx.has_doc_mask = has_doc_mask
         return output
 
     @staticmethod
     def backward(ctx, do):
-        q, k, v, o, lse, group_ids, group_lo, group_hi_excl = ctx.saved_tensors
+        (q, k, v, o, lse, group_ids, group_lo, group_hi_excl,
+         doc_lo, doc_hi_excl) = ctx.saved_tensors
         causal = ctx.causal
         slide_size = ctx.slide_size
         has_group_ids = ctx.has_group_ids
+        has_doc_mask = ctx.has_doc_mask
         g_strides_dq = (
             (group_ids.stride(0), group_ids.stride(1)) if has_group_ids else (0, 0)
+        )
+        doc_strides = (
+            (doc_lo.stride(0), doc_lo.stride(1)) if has_doc_mask else (0, 0)
         )
         B, H_Q, N, D = q.shape
         _, H_KV, _, _ = k.shape
@@ -1663,6 +1742,8 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             GroupIds_ptr=group_ids, GroupLo_ptr=group_lo, GroupHi_ptr=group_hi_excl,
             stride_gb=g_strides_dq[0], stride_gn=g_strides_dq[1],
             HAS_GROUP_IDS=has_group_ids,
+            DocLo_ptr=doc_lo, stride_docb=doc_strides[0], stride_docn=doc_strides[1],
+            HAS_DOC_MASK=has_doc_mask,
             num_warps=num_warps_bw, num_stages=2,
         )
 
@@ -1763,14 +1844,17 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             GroupIds_ptr=group_ids, GroupLo_ptr=group_lo, GroupHi_ptr=group_hi_excl,
             stride_gb=g_strides_dq[0], stride_gn=g_strides_dq[1],
             HAS_GROUP_IDS=has_group_ids,
+            DocHi_ptr=doc_hi_excl, stride_docb=doc_strides[0], stride_docn=doc_strides[1],
+            HAS_DOC_MASK=has_doc_mask,
             num_warps=num_warps_dkv, num_stages=num_stages_dkv,
         )
 
-        return dq, dk, dv, None, None, None, None, None
+        return dq, dk, dv, None, None, None, None, None, None, None
 
 
 def flash_attn_gqa_train(q, k, v, causal=False, slide_size=0,
-                         group_ids=None, group_lo=None, group_hi_excl=None):
+                         group_ids=None, group_lo=None, group_hi_excl=None,
+                         doc_lo=None, doc_hi_excl=None):
     """Flash Attention GQA with backward pass support for training.
 
     Args:
@@ -1782,10 +1866,49 @@ def flash_attn_gqa_train(q, k, v, causal=False, slide_size=0,
         group_ids / group_lo / group_hi_excl: optional (B, N) int32 tensors
             enabling the image-bidirectional OR-mask path for Gemma-4
             multimodal training. See `attention_flash_gqa` for semantics.
+        doc_lo / doc_hi_excl: optional (B, N) int32 tensors enabling
+            packed-document isolation (`packing` training): token n belongs to
+            the document spanning [doc_lo[b, n], doc_hi_excl[b, n]) and never
+            attends outside it. Derive from packed position_ids with
+            `doc_bounds_from_position_ids`. Requires causal=True; composable
+            with slide_size, currently exclusive with group_ids.
     """
+    if doc_lo is not None:
+        assert causal, "doc masking requires causal=True (packed documents)"
+        assert group_ids is None, \
+            "doc masking + image groups not supported yet (packed multimodal)"
     return FlashAttnGQAFunction.apply(
         q, k, v, causal, slide_size, group_ids, group_lo, group_hi_excl,
+        doc_lo, doc_hi_excl,
     )
+
+
+def doc_bounds_from_position_ids(position_ids):
+    """Derive packed-document bounds for `flash_attn_gqa_train` doc masking.
+
+    Args:
+        position_ids: (B, N) int tensor that resets to 0 at each packed
+            document start (the convention used by transformers / ms-swift
+            padding-free packing).
+
+    Returns:
+        (doc_lo, doc_hi_excl): (B, N) int32 contiguous tensors; token n's
+        document spans [doc_lo[b, n], doc_hi_excl[b, n]).
+    """
+    pos = position_ids.to(torch.int32)
+    B, N = pos.shape
+    idx = torch.arange(N, device=pos.device, dtype=torch.int32)
+    # Documents are contiguous and position ids count from 0 within each doc.
+    doc_lo = idx.unsqueeze(0) - pos
+    # doc_hi_excl(n) = the first document start strictly after n (or N).
+    is_start = pos == 0
+    start_idx = torch.where(is_start, idx.expand(B, N), torch.full_like(pos, N))
+    next_start_incl = torch.flip(
+        torch.cummin(torch.flip(start_idx, dims=[-1]), dim=-1).values, dims=[-1])
+    doc_hi_excl = torch.cat(
+        [next_start_incl[:, 1:],
+         torch.full((B, 1), N, device=pos.device, dtype=torch.int32)], dim=1)
+    return doc_lo.contiguous(), doc_hi_excl.contiguous()
 
 
 # --- Benchmark ---

--- a/flash_attn/attention.py
+++ b/flash_attn/attention.py
@@ -2,6 +2,7 @@ import torch
 import triton
 import triton.language as tl
 import math
+import os
 
 
 # =====================================================================
@@ -1716,7 +1717,10 @@ class FlashAttnGQAFunction(torch.autograd.Function):
         #   D=512: (BQ=32, BKV=64, w=8)  — register-constrained, need 8 warps
         #   D=256: (BQ=64, BKV=64, w=4)  — more headroom, larger BQ + fewer warps win
         if D >= 512:
-            BLOCK_Q_BW, BLOCK_KV_BW, num_warps_bw = 32, 64, 8
+            # B300 sweep override (GTFA_DQ_*): H100-tuned defaults regress on sm103
+            BLOCK_Q_BW = int(os.getenv("GTFA_DQ_BQ", "32"))
+            BLOCK_KV_BW = int(os.getenv("GTFA_DQ_BKV", "64"))
+            num_warps_bw = int(os.getenv("GTFA_DQ_W", "8"))
         else:
             BLOCK_Q_BW, BLOCK_KV_BW, num_warps_bw = 64, 64, 4
         BLOCK_Q_BW = min(BLOCK_Q_BW, triton.next_power_of_2(N))
@@ -1744,7 +1748,7 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             HAS_GROUP_IDS=has_group_ids,
             DocLo_ptr=doc_lo, stride_docb=doc_strides[0], stride_docn=doc_strides[1],
             HAS_DOC_MASK=has_doc_mask,
-            num_warps=num_warps_bw, num_stages=2,
+            num_warps=num_warps_bw, num_stages=int(os.getenv("GTFA_DQ_ST", "2")),
         )
 
         # --- dK, dV kernel (packed: KV-major, inline GQA Q-head loop) ---
@@ -1763,8 +1767,10 @@ class FlashAttnGQAFunction(torch.autograd.Function):
             # wins 9.36ms vs old (32,16,8)=13.13ms (-29%); BKV=16 halves
             # dk_acc/dv_acc shmem (32KB×2 vs 64KB×2), freeing budget for BQ=64
             # which cuts the inner Q loop 4× and reuses each Q/dO tile better.
-            BLOCK_KV_DKV, BLOCK_Q_DKV, num_warps_dkv = 16, 64, 4
-            num_stages_dkv = 2
+            BLOCK_KV_DKV = int(os.getenv("GTFA_DKV_BKV", "16"))
+            BLOCK_Q_DKV = int(os.getenv("GTFA_DKV_BQ", "64"))
+            num_warps_dkv = int(os.getenv("GTFA_DKV_W", "4"))
+            num_stages_dkv = int(os.getenv("GTFA_DKV_ST", "2"))
         else:
             # D<512: (BKV=64, BQ=128, w=8, s=1) is the big-tile config that
             # wins when grid is healthy. We use it in TWO regimes:

--- a/flash_attn/hf_integration.py
+++ b/flash_attn/hf_integration.py
@@ -23,9 +23,12 @@ changes required.
 from __future__ import annotations
 
 import contextvars
+import os
 from typing import NamedTuple
 
 import torch
+
+_probe_seen: set = set()
 
 from .attention import doc_bounds_from_position_ids, flash_attn_gqa_train
 
@@ -160,6 +163,22 @@ def triton_gqa_attention(
     Raises NotImplementedError for features the kernel doesn't support
     (softcap, nonzero dropout) — fail loudly rather than produce wrong numerics.
     """
+    if os.environ.get("GTFA_SHAPE_PROBE") == "1" and os.environ.get("RANK", "0") == "0":
+        sig = (tuple(query.shape), tuple(key.shape), tuple(value.shape), sliding_window,
+               key.data_ptr() == value.data_ptr(), scaling)
+        if sig not in _probe_seen:
+            _probe_seen.add(sig)
+            pos = kwargs.get("position_ids")
+            ndocs = None
+            pos_shape = tuple(pos.shape) if pos is not None else None
+            if pos is not None and pos.shape[-1] == query.shape[2]:
+                ndocs = int((pos[..., 1:] <= pos[..., :-1]).sum().item()) + 1
+            print(f"[GTFA-probe] position_ids shape={pos_shape} kwargs={sorted(kwargs.keys())}", flush=True)
+            print(f"[GTFA-probe] q{tuple(query.shape)} k{tuple(key.shape)} v{tuple(value.shape)} "
+                  f"win={sliding_window} k_is_v={key.data_ptr() == value.data_ptr()} "
+                  f"scaling={scaling} ndocs={ndocs}",
+                  flush=True)
+
     # Reconcile scaling. Our kernel bakes in 1/sqrt(D) internally. If the module
     # passes a different `scaling` (e.g., Gemma4 passes 1.0 because scaling is
     # folded into q_norm), pre-multiply q to cancel the kernel's internal scale.
@@ -189,9 +208,14 @@ def triton_gqa_attention(
     # (reset to 0 at each doc start) so causal attention never crosses packed
     # document boundaries — the kernel-side equivalent of FA varlen cu_seqlens.
     doc_lo = doc_hi_excl = None
+    pos_structure_known = False
     position_ids = kwargs.get("position_ids")
     if position_ids is not None and is_causal and position_ids.shape[-1] == query.shape[2]:
         doc_lo, doc_hi_excl = _packed_doc_bounds(position_ids)
+        # position_ids were readable: doc_lo=None here means a single monotonic
+        # sequence, for which a BlockMask/4D mask is plain causal(+window) and
+        # the kernel's native masking is equivalent — no need to fail below.
+        pos_structure_known = True
     if doc_lo is not None and use_image_groups:
         raise NotImplementedError(
             "triton_gqa_attention: packed documents + image-bidirectional groups "
@@ -201,8 +225,8 @@ def triton_gqa_attention(
     # state is in context, image bidirectional info would be silently
     # dropped — fail loudly so the user installs the patch. Packed-doc inputs
     # are exempt: the doc bounds fully reproduce the mask's structure.
-    if (group_state is None) and (doc_lo is None) and (attention_mask is not None) \
-            and slide > 0 and is_causal:
+    if (group_state is None) and (doc_lo is None) and not pos_structure_known \
+            and (attention_mask is not None) and slide > 0 and is_causal:
         is_4d = isinstance(attention_mask, torch.Tensor) and attention_mask.dim() == 4
         from torch.nn.attention.flex_attention import BlockMask
         is_blockmask = isinstance(attention_mask, BlockMask)

--- a/flash_attn/hf_integration.py
+++ b/flash_attn/hf_integration.py
@@ -27,7 +27,38 @@ from typing import NamedTuple
 
 import torch
 
-from .attention import flash_attn_gqa_train
+from .attention import doc_bounds_from_position_ids, flash_attn_gqa_train
+
+
+# =====================================================================
+# Packed-document isolation plumbing (`packing` / padding-free training)
+#
+# ms-swift / transformers packing flattens multiple documents into one row and
+# passes position_ids that reset to 0 at each document start. FA2 recovers the
+# document boundaries via cu_seqlens; our kernel takes (doc_lo, doc_hi_excl)
+# per-token bounds instead. The same position_ids tensor is passed to every
+# decoder layer within one model forward, so a single-slot cache keyed on the
+# tensor's storage collapses the derivation (and its GPU sync) to once per step.
+# =====================================================================
+
+_doc_bounds_cache = {"key": None, "value": (None, None)}
+
+
+def _packed_doc_bounds(position_ids: torch.Tensor):
+    """Return (doc_lo, doc_hi_excl) if position_ids indicate packed documents,
+    else (None, None). Cached across layers of the same forward pass."""
+    key = (position_ids.data_ptr(), position_ids.shape[-1], position_ids._version)
+    if _doc_bounds_cache["key"] == key:
+        return _doc_bounds_cache["value"]
+    pos = position_ids if position_ids.dim() == 2 else position_ids.reshape(1, -1)
+    # Packed iff position ids restart mid-row: more zeros than rows.
+    if bool((pos == 0).sum() > pos.shape[0]):
+        value = doc_bounds_from_position_ids(pos)
+    else:
+        value = (None, None)
+    _doc_bounds_cache["key"] = key
+    _doc_bounds_cache["value"] = value
+    return value
 
 
 # =====================================================================
@@ -154,10 +185,24 @@ def triton_gqa_attention(
     group_state = _image_group_state.get()
     use_image_groups = (group_state is not None) and (slide > 0) and is_causal
 
+    # Packed-document isolation: recover doc bounds from packed position_ids
+    # (reset to 0 at each doc start) so causal attention never crosses packed
+    # document boundaries — the kernel-side equivalent of FA varlen cu_seqlens.
+    doc_lo = doc_hi_excl = None
+    position_ids = kwargs.get("position_ids")
+    if position_ids is not None and is_causal and position_ids.shape[-1] == query.shape[2]:
+        doc_lo, doc_hi_excl = _packed_doc_bounds(position_ids)
+    if doc_lo is not None and use_image_groups:
+        raise NotImplementedError(
+            "triton_gqa_attention: packed documents + image-bidirectional groups "
+            "(packed multimodal) is not supported yet")
+
     # Defensive guard: if the caller passed a 4D / BlockMask but no group
     # state is in context, image bidirectional info would be silently
-    # dropped — fail loudly so the user installs the patch.
-    if (group_state is None) and (attention_mask is not None) and slide > 0 and is_causal:
+    # dropped — fail loudly so the user installs the patch. Packed-doc inputs
+    # are exempt: the doc bounds fully reproduce the mask's structure.
+    if (group_state is None) and (doc_lo is None) and (attention_mask is not None) \
+            and slide > 0 and is_causal:
         is_4d = isinstance(attention_mask, torch.Tensor) and attention_mask.dim() == 4
         from torch.nn.attention.flex_attention import BlockMask
         is_blockmask = isinstance(attention_mask, BlockMask)
@@ -195,6 +240,7 @@ def triton_gqa_attention(
             group_ids=group_args[0],
             group_lo=group_args[1],
             group_hi_excl=group_args[2],
+            doc_lo=doc_lo, doc_hi_excl=doc_hi_excl,
         )
     out = out.transpose(1, 2).contiguous()
     return out, None  # (attn_output, attn_weights)

--- a/tests/test_doc_mask.py
+++ b/tests/test_doc_mask.py
@@ -1,0 +1,147 @@
+"""Packed-document isolation (doc masking) correctness tests.
+
+Reference: SDPA in float32 with an explicit block-diagonal causal (+ optional
+sliding window) bool mask built from the same packed position_ids.
+
+Checks (per repo convention: fp32 cos sim, threshold 0.9999):
+  1. fwd output + dq/dk/dv grads vs reference, for
+     {D=512 full causal, D=256 slide=1024} x {GQA 2:1, 8:1} x {B=1, B=2}
+  2. degenerate single-document input == plain causal path (no doc mask)
+  3. doc_bounds_from_position_ids unit check against a python loop
+
+Run: python tests/test_doc_mask.py
+"""
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from flash_attn import doc_bounds_from_position_ids, flash_attn_gqa_train  # noqa: E402
+
+
+def make_packed_position_ids(N, doc_lens, device):
+    pos = torch.empty(N, dtype=torch.int64, device=device)
+    i = 0
+    for L in doc_lens:
+        L = min(L, N - i)
+        pos[i:i + L] = torch.arange(L, device=device)
+        i += L
+        if i >= N:
+            break
+    assert i == N, "doc_lens must cover N"
+    return pos
+
+
+def ref_attention(q, k, v, pos, slide_size):
+    """float32 SDPA with explicit block-diag causal (+window) mask."""
+    B, H_Q, N, D = q.shape
+    _, H_KV, _, _ = k.shape
+    if H_Q != H_KV:
+        r = H_Q // H_KV
+        k = k.repeat_interleave(r, dim=1)
+        v = v.repeat_interleave(r, dim=1)
+    idx = torch.arange(N, device=q.device)
+    doc_lo = idx.unsqueeze(0) - pos  # (B, N)
+    allowed = (idx[None, None, :] <= idx[None, :, None])  # causal (1, N, N)
+    allowed = allowed & (idx[None, None, :] >= doc_lo[:, :, None])  # same doc
+    if slide_size > 0:
+        allowed = allowed & (idx[None, :, None] - idx[None, None, :] < slide_size)
+    return F.scaled_dot_product_attention(
+        q.float(), k.float(), v.float(), attn_mask=allowed.unsqueeze(1))
+
+
+def cos(a, b):
+    return F.cosine_similarity(
+        a.float().flatten(), b.float().flatten(), dim=0).item()
+
+
+def run_case(B, H_Q, H_KV, N, D, slide, seed=0):
+    torch.manual_seed(seed)
+    device = "cuda"
+    doc_lens_all = []
+    pos_rows = []
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    for _ in range(B):
+        lens, tot = [], 0
+        while tot < N:
+            L = int(torch.randint(60, 1600, (1,), generator=g))
+            L = min(L, N - tot)
+            lens.append(L)
+            tot += L
+        doc_lens_all.append(lens)
+        pos_rows.append(make_packed_position_ids(N, lens, device))
+    pos = torch.stack(pos_rows)  # (B, N)
+
+    q = torch.randn(B, H_Q, N, D, device=device, dtype=torch.bfloat16, requires_grad=True)
+    k = torch.randn(B, H_KV, N, D, device=device, dtype=torch.bfloat16, requires_grad=True)
+    v = torch.randn(B, H_KV, N, D, device=device, dtype=torch.bfloat16, requires_grad=True)
+    do = torch.randn(B, H_Q, N, D, device=device, dtype=torch.bfloat16)
+
+    doc_lo, doc_hi = doc_bounds_from_position_ids(pos)
+    out = flash_attn_gqa_train(q, k, v, causal=True, slide_size=slide,
+                               doc_lo=doc_lo, doc_hi_excl=doc_hi)
+    out.backward(do)
+    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    q.grad = k.grad = v.grad = None
+
+    q2 = q.detach().clone().requires_grad_(True)
+    k2 = k.detach().clone().requires_grad_(True)
+    v2 = v.detach().clone().requires_grad_(True)
+    ref = ref_attention(q2, k2, v2, pos, slide)
+    ref.backward(do.float())
+
+    sims = {
+        "out": cos(out, ref),
+        "dq": cos(dq, q2.grad),
+        "dk": cos(dk, k2.grad),
+        "dv": cos(dv, v2.grad),
+    }
+    ok = all(s >= 0.9999 for s in sims.values()) and not out.isnan().any()
+    ndocs = sum(len(x) for x in doc_lens_all)
+    print(f"B={B} H_Q={H_Q} H_KV={H_KV} N={N} D={D} slide={slide} docs={ndocs}: "
+          + " ".join(f"{k_}={v_:.6f}" for k_, v_ in sims.items())
+          + ("  PASS" if ok else "  FAIL"))
+    return ok
+
+
+def test_single_doc_equals_plain_causal():
+    """pos = arange (one doc) must reproduce the no-doc-mask path."""
+    torch.manual_seed(1)
+    B, H_Q, H_KV, N, D = 1, 16, 8, 2048, 512
+    q = torch.randn(B, H_Q, N, D, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(B, H_KV, N, D, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(B, H_KV, N, D, device="cuda", dtype=torch.bfloat16)
+    pos = torch.arange(N, device="cuda").unsqueeze(0)
+    doc_lo, doc_hi = doc_bounds_from_position_ids(pos)
+    a = flash_attn_gqa_train(q, k, v, causal=True, doc_lo=doc_lo, doc_hi_excl=doc_hi)
+    b = flash_attn_gqa_train(q, k, v, causal=True)
+    sim = cos(a, b)
+    ok = sim >= 0.999999
+    print(f"single-doc == plain causal: cos={sim:.8f} {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def test_bounds_helper():
+    pos = torch.tensor([[0, 1, 2, 0, 1, 0, 1, 2, 3]], device="cuda")
+    lo, hi = doc_bounds_from_position_ids(pos)
+    exp_lo = [0, 0, 0, 3, 3, 5, 5, 5, 5]
+    exp_hi = [3, 3, 3, 5, 5, 9, 9, 9, 9]
+    ok = lo[0].tolist() == exp_lo and hi[0].tolist() == exp_hi
+    print(f"doc_bounds helper: {'PASS' if ok else 'FAIL'} lo={lo[0].tolist()} hi={hi[0].tolist()}")
+    return ok
+
+
+if __name__ == "__main__":
+    results = [test_bounds_helper(), test_single_doc_equals_plain_causal()]
+    # Gemma-4-31B-ish config (H_Q=16, H_KV=8): full layers D=512, sliding D=256
+    for B in (1, 2):
+        results.append(run_case(B, 16, 8, 4096, 512, 0))
+        results.append(run_case(B, 16, 8, 4096, 256, 1024))
+    # Gemma-4-E2B config (GQA 8:1)
+    results.append(run_case(1, 8, 1, 4096, 512, 0))
+    results.append(run_case(1, 8, 1, 4096, 256, 1024))
+    print("=" * 60)
+    print("ALL PASS" if all(results) else "SOME FAILED")
+    sys.exit(0 if all(results) else 1)

--- a/tests/test_packed_dkv.py
+++ b/tests/test_packed_dkv.py
@@ -32,7 +32,10 @@ def run_forward_with_lse(q, k, v, *, causal, slide_size):
     _, H_KV, _, _ = k.shape
     if slide_size > 0 and slide_size >= N:
         slide_size = 0
-    BQ = min(64 if D >= 512 else 128, triton.next_power_of_2(N))
+    # sm_100+ needs smaller tiles (227KB smem/SM) — mirror the wrapper defaults.
+    _sm100 = torch.cuda.get_device_capability()[0] >= 10
+    BQ = min((32 if _sm100 else 64) if D >= 512 else (64 if _sm100 else 128),
+             triton.next_power_of_2(N))
     BKV = min(32 if D >= 512 else 64, triton.next_power_of_2(N))
     num_warps = 8 if D >= 256 else 4
     output = torch.empty_like(q)
@@ -51,6 +54,7 @@ def run_forward_with_lse(q, k, v, *, causal, slide_size):
         stride_lsen=lse.stride(2), STORE_LSE=True,
         GroupIds_ptr=None, GroupLo_ptr=None, GroupHi_ptr=None,
         stride_gb=0, stride_gn=0, HAS_GROUP_IDS=False,
+        DocLo_ptr=None, stride_docb=0, stride_docn=0, HAS_DOC_MASK=False,
         num_warps=num_warps, num_stages=2,
     )
     return output, lse, slide_size
@@ -152,6 +156,7 @@ def run_dkv_packed(q, k, v, do, lse, delta, *, causal, slide_size,
         Q_SPLITS=1,
         GroupIds_ptr=None, GroupLo_ptr=None, GroupHi_ptr=None,
         stride_gb=0, stride_gn=0, HAS_GROUP_IDS=False,
+        DocHi_ptr=None, stride_docb=0, stride_docn=0, HAS_DOC_MASK=False,
         num_warps=num_warps, num_stages=2,
     )
     return dk, dv


### PR DESCRIPTION
## Motivation

Sequence-packing (padding-free) training requires document isolation in attention. The batched kernels had none, so packed inputs either got rejected upstream (ms-swift gates packing on FA-style impls) or — worse — silently attended across document boundaries. This PR adds in-kernel isolation to the batched path, plus the config changes needed to run on B300 (sm_103a).

## Design

- **Per-token document bounds instead of cu_seqlens**: packed `position_ids` restart at 0 per document (the transformers/ms-swift convention), so `doc_lo(i) = i − pos(i)` and a reversed cummin gives `doc_hi_excl`. `doc_bounds_from_position_ids()` derives both in a few tensor ops.
- **fwd/dQ**: mask `kv ≥ doc_lo(q)`, and the KV loop start skips to the tile's earliest doc start — attention FLOPs scale with document length (the cu_seqlens-equivalent property for the batched layout).
- **dKV (packed)**: mask `q < doc_hi(kv)`, Q loop clamped at the tile's furthest doc end.
- **Zero-regression**: all new kernel params are `tl.constexpr`-gated; with `HAS_DOC_MASK=False` the generated code is identical to before (single-doc degenerate input matches the plain causal path).
- **HF adapter**: packed inputs auto-detected from `kwargs["position_ids"]` (single-slot cache, one GPU sync per model forward) — no explicit cu_seqlens plumbing required by callers.

## B300 / sm_103a support

H100-tuned tiles exceed sm_103a's 227 KB smem (274 KB needed), and BQ=64 @ D=512 miscompiles (misaligned address). Capability-gated defaults, swept on-device: D=512 → (BQ=32, BKV=32), 2.73 ms vs 27 ms SDPA @ N=4096; D=256 → (BQ=64, BKV=64), 0.25 ms. Environment notes: Triton 3.4's bundled ptxas predates sm_103a — use `TRITON_PTXAS_PATH` pointing at a CUDA ≥12.9 ptxas so PTX ≥8.8 can target it.

## Validation

- `tests/test_doc_mask.py`: fp32 block-diagonal SDPA reference, fwd + dq/dk/dv, cos ≥ 0.99999 across D {256,512} × GQA {2:1, 8:1} × slide {0,1024} × B {1,2} × random layouts. Tier-0 (`test_packed_dkv.py`) passes.
- Bitwise perturbation-invariance (fwd **and** bwd): flipping values inside doc A leaves doc B's out/dq/dk/dv bit-identical; negative control (no isolation) shows max|Δ| ≈ 29.
- End-to-end on gemma-4-31B (B300, FSDP2, packed CPT): loss matches an SDPA block-diagonal reference step-by-step within bf16 noise; 700+ steps of healthy convergence.

## Relationship to #1 (FA2-varlen)

Complementary, not competing. We cross-validated both implementations on B300: 24/24 PASS against the same fp32 reference (kernel sweep incl. edge-case layouts, bitwise fwd+bwd isolation for both, #1's adapter e2e on 31B), fwd+bwd within ±6% at real training shapes. Two integration notes for #1: (a) its adapter silently falls back to the **non-isolated** batched path when no cu_seqlens are provided (exactly what transformers/ms-swift-style inputs look like) — this PR makes that fallback path isolation-safe, and the `doc_bounds_from_position_ids` doc-start array is directly reusable as cu_seqlens for auto-deriving varlen inputs; (b) #1's varlen kernels run on sm_103a unmodified (their conservative tiles fit 227 KB). Happy to help converge: per-doc-grid varlen as the packed fast path, batched doc-mask as the safe fallback, shared verification suite.

## Limitations

- Packed multimodal (doc masking + image-bidirectional groups) not supported yet — guarded with an explicit error.
- Causal-only (asserted).
- `context/baseline.md` entries per repo convention to follow in a docs commit if desired.
