### PR TITLE
Harden Ulysses context-parallel integration for Gemma 4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -193,10 +193,34 @@ if hasattr(model.config, "text_config"):                      # 3. opt in nested
 out = model(input_ids)
 ```
 
+Registration uses Transformers' public `AttentionInterface.register()` API.
+The kernel owns causal and sliding-window masking; packed input uses the
+separate varlen adapter described below.
+
 **transformers 5.5.4 users**: call
 `patch_transformers_5_5_4_flash_attn_key()` once before any config load to
 work around the upstream `KeyError: 'flash_attn'` bug
 ([details](docs/integration.md#transformers-554-keyerror-workaround)).
+
+## Ulysses context parallelism
+
+The package includes a Ulysses adapter that scatters attention heads and
+gathers sequence shards before running the Triton kernel. Register it only
+after `torch.distributed` and the context-parallel process group exist:
+
+```python
+from gemma_triton_flash_attn import register_triton_attention_ulysses
+
+register_triton_attention_ulysses(cp_group, name="triton_gqa_ulysses")
+model.set_attn_implementation("triton_gqa_ulysses")
+```
+
+The dense adapter supports causal/full and causal/sliding attention. Q heads
+must be divisible by the CP size. When a Gemma 4 global layer has fewer KV
+heads than CP ranks, K/V are expanded before the all-to-all and gradients are
+reduced back through `repeat_interleave` autograd. Packed batches should use
+`register_triton_attention_varlen_ulysses`; dense CP deliberately rejects an
+explicit attention mask instead of silently dropping it.
 
 ## Variable-length (packed) sequences
 
@@ -255,12 +279,20 @@ typically 1.3×–4.5× faster end-to-end on H100.
 ## Installation
 
 ```bash
-git clone <repo>
-cd kernel
-pip install -e .
+pip install "gemma-triton-flash-attn[hf]"
 ```
 
-Requires: `torch>=2.0`, `triton>=3.0`, CUDA GPU (tested on H100).
+To install from source:
+
+```bash
+git clone https://github.com/zzhhjjj/gemma-triton-flash-attn.git
+cd gemma-triton-flash-attn
+pip install -e ".[hf]"
+```
+
+Requires: Python 3.10+, `torch>=2.0`, `triton>=3.0`, and a CUDA GPU for
+kernel execution (tested on H100/H200). The CPU/Gloo CP test exercises the
+distributed layout and autograd wrapper without launching Triton.
 
 For the integration tests (real Gemma-4-E2B download):
 
@@ -271,7 +303,14 @@ pip install -r requirements.txt          # transformers 5.5.4, accelerate, etc.
 ## Running the tests
 
 ```bash
-# 1) Adapter unit test — 24 cases (GQA × SWA × D), seconds
+# Public registration + two-rank Gloo Ulysses forward/backward
+pytest -q tests/test_cp_distributed.py
+
+# Actual Triton + NCCL Ulysses at D=256 and D=512
+torchrun --standalone --nproc-per-node=2 tests/test_cp_cuda.py
+# Repeat with 4 or 8 ranks to cover H_KV < CP replication.
+
+# Adapter unit test — 24 cases (GQA × SWA × D), seconds
 python tests/gemma4_integration/test_adapter.py
 
 # 2) Real Gemma-4-E2B end-to-end — downloads 5 GB on first run

--- a/context/arch.md
+++ b/context/arch.md
@@ -105,7 +105,7 @@ Stride 参数完全通用，支持非 contiguous tensor（但 contiguous 最快�
 
 | 函数 | 说明 |
 |------|------|
-| `register_triton_attention(name="triton_gqa")` | 注册到 `ALL_ATTENTION_FUNCTIONS[name]` |
+| `register_triton_attention(name="triton_gqa")` | 通过公共 `AttentionInterface.register()` API 注册 |
 | `triton_gqa_attention(module, q, k, v, attention_mask, *, scaling, sliding_window, ...)` | adapter 本体 |
 | `patch_transformers_5_5_4_flash_attn_key()` | transformers 5.5.4 `KeyError: 'flash_attn'` bug 的 workaround |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,14 +6,26 @@ All exports live in `gemma_triton_flash_attn` (package name: `gemma-triton-flash
 
 ### `register_triton_attention(name: str = "triton_gqa") -> None`
 
-Register the Triton kernel in transformers' `ALL_ATTENTION_FUNCTIONS` under
-the given name. Safe to call multiple times (idempotent).
+Register the Triton kernel with transformers' public `AttentionInterface`
+under the given name. Safe to call multiple times.
 
 ```python
 from gemma_triton_flash_attn import register_triton_attention
 register_triton_attention()                 # "triton_gqa" (default)
 register_triton_attention(name="my_attn")   # or pick your own key
 ```
+
+### `register_triton_attention_ulysses(cp_group, name: str = "triton_gqa_ulysses") -> None`
+
+Register the dense attention adapter with differentiable Ulysses all-to-all.
+Call it after `torch.distributed` is initialized. Q heads and post-replication
+KV heads must be divisible by the CP group size.
+
+### `register_triton_attention_varlen_ulysses(cp_group, name: str = "triton_gqa_varlen_ulysses") -> None`
+
+Register the packed, batch-size-one varlen adapter with Ulysses all-to-all.
+Packed sequence offsets must be installed with `set_varlen_cu_seqlens` before
+the model forward.
 
 ### `triton_gqa_attention(module, q, k, v, attention_mask, *, scaling, sliding_window, dropout=0.0, softcap=0.0, **kwargs) -> (out, None)`
 
@@ -71,7 +83,7 @@ v: (B, N_KV_HEADS, N, D)
 The following raise `NotImplementedError` (adapter) or simply aren't
 implemented (direct kernel):
 
-- Variable-length sequences / padding mask
+- Arbitrary additive masks on the dense adapter
 - ALiBi or positional bias injection
 - `softcap ≠ 0`
 - `dropout > 0`

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -6,17 +6,41 @@ transformers 5.5.4.
 
 ## Registry mechanism
 
-transformers ≥ 5.5 exposes a pluggable dict, `ALL_ATTENTION_FUNCTIONS`, keyed
-by implementation name (`"sdpa"`, `"eager"`, `"flash_attention_2"`, …). Every
-attention layer looks up its kernel by
-`ALL_ATTENTION_FUNCTIONS[config._attn_implementation]`. We register one extra
-entry, `"triton_gqa"`, pointing at the adapter.
+transformers ≥ 5.5 exposes the public `AttentionInterface` registry, keyed by
+implementation name (`"sdpa"`, `"eager"`, `"flash_attention_2"`, …). Every
+attention layer resolves its kernel through that interface. We call
+`AttentionInterface.register()` to add a `"triton_gqa"` entry pointing at the
+adapter; no private registry mutation is required.
 
 ```python
 from gemma_triton_flash_attn import register_triton_attention
 register_triton_attention()                # default name: "triton_gqa"
 register_triton_attention(name="my_attn")  # or pick your own
 ```
+
+The custom implementation intentionally does not register an
+`AttentionMaskInterface` formatter: this kernel creates causal and
+sliding-window masks internally. Dense Ulysses rejects explicit masks, and
+packed samples use the varlen registration, so unsupported masks fail loudly
+instead of being ignored.
+
+## Ulysses context parallelism
+
+The Ulysses registration wraps the same adapter with three differentiable
+all-to-all operations before attention and the inverse operation afterward:
+
+```python
+from gemma_triton_flash_attn import register_triton_attention_ulysses
+
+register_triton_attention_ulysses(cp_group, name="triton_gqa_ulysses")
+model.set_attn_implementation("triton_gqa_ulysses")
+```
+
+Input Q/K/V layout is `(B, H, N_local, D)`. Each rank receives
+`(B, H/cp, N_full, D)` for local attention. Gemma 4 global layers can have
+fewer KV heads than CP ranks; in that case K/V are expanded to the Q-head
+count before communication. The inverse all-to-all restores
+`(B, N_local, H, D)` for Transformers.
 
 ## What the adapter does
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,5 +1,27 @@
 # Testing
 
+## Distributed context parallelism
+
+The CPU test launches two Gloo ranks and compares the Ulysses output and
+dQ/dK/dV against full-sequence PyTorch attention. It covers both Gemma 4
+attention dimensions and the `H_KV < cp_size` replication path:
+
+```bash
+pytest -q tests/test_cp_distributed.py
+```
+
+The CUDA test launches the real Triton kernels under NCCL. It supports two,
+four, or eight local GPUs:
+
+```bash
+torchrun --standalone --nproc-per-node=2 tests/test_cp_cuda.py
+torchrun --standalone --nproc-per-node=4 tests/test_cp_cuda.py
+torchrun --standalone --nproc-per-node=8 tests/test_cp_cuda.py
+```
+
+For multi-node validation, use the cluster's normal `torchrun` rendezvous
+arguments and execute the same script on every node.
+
 ## Adapter unit test — `tests/gemma4_integration/test_adapter.py`
 
 Exercises the registered `triton_gqa` adapter directly against an SDPA

--- a/flash_attn/__init__.py
+++ b/flash_attn/__init__.py
@@ -51,6 +51,7 @@ from .attention import (
     # Standard scaled dot-product attention (PyTorch fallback)
     attention,
 )
+
 # HuggingFace transformers integration
 from .hf_integration import (
     register_triton_attention,
@@ -67,7 +68,7 @@ from .hf_integration import (
     patch_gemma4_image_group_ids_for_kernel,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = [
     "attention_flash_gqa",
@@ -85,7 +86,13 @@ __all__ = [
     # HF transformers integration
     "register_triton_attention",
     "register_triton_attention_ulysses",
+    "register_triton_attention_varlen",
+    "register_triton_attention_varlen_ulysses",
     "triton_gqa_attention",
+    "triton_gqa_varlen_attention",
+    "set_varlen_cu_seqlens",
+    "clear_varlen_cu_seqlens",
+    "cu_seqlens_from_2d_indices",
     "patch_transformers_5_5_4_flash_attn_key",
     "patch_gemma4_shared_kv_states_for_fsdp2",
     "patch_gemma4_image_group_ids_for_kernel",

--- a/flash_attn/cp_comm.py
+++ b/flash_attn/cp_comm.py
@@ -1,9 +1,28 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates and the LlamaFactory team.
+# Copyright 2026 gemma-triton-flash-attn contributors.
+#
+# This code is inspired by the Bytedance verl Ulysses implementation:
+# https://github.com/verl-project/verl/blob/77476af84cc074edf5a6437f8d5ea418d7a54916/verl/utils/ulysses.py
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Context-parallel all-to-all primitives.
 
 Self-contained copy of LlamaFactory v1's SeqAllToAll4D so the kernel package
 has no LlamaFactory import. Original source:
 LLaMA-Factory/src/llamafactory/v1/plugins/model_plugins/parallelization/seq_comm.py
 """
+
 from __future__ import annotations
 
 from typing import Any, Optional
@@ -19,10 +38,39 @@ def all_to_all_tensor(
     gather_dim: int,
     group: Optional[dist.ProcessGroup] = None,
 ) -> Tensor:
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError(
+            "all_to_all_tensor requires an initialized torch.distributed process group."
+        )
+
     seq_world_size = dist.get_world_size(group)
-    input_list = [t.contiguous() for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)]
-    output_list = [torch.empty_like(input_list[0]) for _ in range(seq_world_size)]
-    dist.all_to_all(output_list, input_list, group=group)
+    scatter_size = local_input.shape[scatter_dim]
+    if scatter_size % seq_world_size != 0:
+        raise ValueError(
+            f"Tensor dimension {scatter_dim} (size={scatter_size}) must be divisible by "
+            f"the process-group size ({seq_world_size})."
+        )
+
+    input_list = [
+        t.contiguous()
+        for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)
+    ]
+    if dist.get_backend(group) == "gloo":
+        # Gloo does not implement list-based all-to-all. Its CPU-only path is
+        # useful for CI, so emulate the same exchange with an all-gather. The
+        # production NCCL path below remains the memory-efficient collective.
+        gathered_inputs = [torch.empty_like(local_input) for _ in range(seq_world_size)]
+        dist.all_gather(gathered_inputs, local_input.contiguous(), group=group)
+        group_rank = dist.get_rank(group)
+        output_list = [
+            torch.tensor_split(source, seq_world_size, scatter_dim)[
+                group_rank
+            ].contiguous()
+            for source in gathered_inputs
+        ]
+    else:
+        output_list = [torch.empty_like(input_list[0]) for _ in range(seq_world_size)]
+        dist.all_to_all(output_list, input_list, group=group)
     return torch.cat(output_list, dim=gather_dim).contiguous()
 
 
@@ -44,7 +92,9 @@ class SeqAllToAll4D(torch.autograd.Function):
     def backward(ctx: Any, *grad_output: Tensor) -> tuple[None, Tensor, None, None]:
         return (
             None,
-            all_to_all_tensor(grad_output[0], ctx.gather_dim, ctx.scatter_dim, ctx.group),
+            all_to_all_tensor(
+                grad_output[0], ctx.gather_dim, ctx.scatter_dim, ctx.group
+            ),
             None,
             None,
         )

--- a/flash_attn/hf_integration.py
+++ b/flash_attn/hf_integration.py
@@ -1,8 +1,8 @@
 """HuggingFace transformers integration.
 
 Registers the Triton GQA kernel as a pluggable attention implementation that
-any transformers model using the `ALL_ATTENTION_FUNCTIONS` registry can opt
-into via `model.config._attn_implementation = "triton_gqa"`.
+any Transformers model using `AttentionInterface` can opt into via
+`model.config._attn_implementation = "triton_gqa"`.
 
 Tested on transformers>=5.5 with Gemma4-style models (sliding + full causal
 interleaved GQA).
@@ -20,10 +20,11 @@ Typical usage:
 Every attention layer now routes through the Triton kernel. No model code
 changes required.
 """
+
 from __future__ import annotations
 
 import contextvars
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 
 import torch
 
@@ -51,9 +52,10 @@ from .attention import flash_attn_gqa_train
 # Full-attention layers ignore them (matches upstream).
 # =====================================================================
 
+
 class _ImageGroupState(NamedTuple):
-    group_ids: torch.Tensor      # (B, N) int32; -1 = non-vision token
-    group_lo: torch.Tensor       # (B, N) int32; first KV idx in same group (or self)
+    group_ids: torch.Tensor  # (B, N) int32; -1 = non-vision token
+    group_lo: torch.Tensor  # (B, N) int32; first KV idx in same group (or self)
     group_hi_excl: torch.Tensor  # (B, N) int32; last KV idx+1 in same group (or self+1)
 
 
@@ -109,9 +111,9 @@ def _compute_image_group_state(mm_token_type_ids: torch.Tensor) -> _ImageGroupSt
 
 def triton_gqa_attention(
     module,
-    query: torch.Tensor,            # (B, H_Q, N, D)
-    key: torch.Tensor,              # (B, H_KV, N, D)
-    value: torch.Tensor,            # (B, H_KV, N, D)
+    query: torch.Tensor,  # (B, H_Q, N, D)
+    key: torch.Tensor,  # (B, H_KV, N, D)
+    value: torch.Tensor,  # (B, H_KV, N, D)
     attention_mask: torch.Tensor | None,
     dropout: float = 0.0,
     scaling: float | None = None,
@@ -132,7 +134,7 @@ def triton_gqa_attention(
     # Reconcile scaling. Our kernel bakes in 1/sqrt(D) internally. If the module
     # passes a different `scaling` (e.g., Gemma4 passes 1.0 because scaling is
     # folded into q_norm), pre-multiply q to cancel the kernel's internal scale.
-    scale = scaling if scaling is not None else module.head_dim ** -0.5
+    scale = scaling if scaling is not None else module.head_dim**-0.5
     default_scale = query.shape[-1] ** -0.5
     if scale != default_scale:
         query = query * (scale / default_scale)
@@ -157,9 +159,15 @@ def triton_gqa_attention(
     # Defensive guard: if the caller passed a 4D / BlockMask but no group
     # state is in context, image bidirectional info would be silently
     # dropped — fail loudly so the user installs the patch.
-    if (group_state is None) and (attention_mask is not None) and slide > 0 and is_causal:
+    if (
+        (group_state is None)
+        and (attention_mask is not None)
+        and slide > 0
+        and is_causal
+    ):
         is_4d = isinstance(attention_mask, torch.Tensor) and attention_mask.dim() == 4
         from torch.nn.attention.flex_attention import BlockMask
+
         is_blockmask = isinstance(attention_mask, BlockMask)
         if is_4d or is_blockmask:
             raise RuntimeError(
@@ -190,8 +198,11 @@ def triton_gqa_attention(
     # stream — silently producing NaN output. Wrap the launch in a device ctx.
     with torch.cuda.device(query.device):
         out = flash_attn_gqa_train(
-            query, key, value,
-            causal=is_causal, slide_size=slide,
+            query,
+            key,
+            value,
+            causal=is_causal,
+            slide_size=slide,
             group_ids=group_args[0],
             group_lo=group_args[1],
             group_hi_excl=group_args[2],
@@ -201,15 +212,130 @@ def triton_gqa_attention(
 
 
 def register_triton_attention(name: str = "triton_gqa") -> None:
-    """Register the Triton GQA kernel under the given name in transformers'
-    `ALL_ATTENTION_FUNCTIONS` registry.
+    """Register the Triton GQA kernel through Transformers' public attention API.
 
     After calling this, set `model.config._attn_implementation = name` (and
     `model.config.text_config._attn_implementation = name` for multimodal
     configs) to route every attention layer through the Triton kernel.
     """
-    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-    ALL_ATTENTION_FUNCTIONS[name] = triton_gqa_attention
+    _register_attention(name, triton_gqa_attention)
+
+
+def _register_attention(name: str, attention_fn: Callable) -> None:
+    """Register an attention callable through Transformers' public API."""
+    if not name or name == "eager":
+        raise ValueError(
+            "A custom attention implementation needs a non-empty name other than 'eager'."
+        )
+
+    try:
+        from transformers import AttentionInterface
+    except ImportError as exc:
+        raise ImportError(
+            "gemma-triton-flash-attn's Hugging Face integration requires transformers>=5.5.0."
+        ) from exc
+
+    AttentionInterface.register(name, attention_fn)
+
+
+def _build_ulysses_attention(
+    cp_group, attention_fn: Callable = triton_gqa_attention
+) -> Callable:
+    """Build a Transformers attention adapter with Ulysses all-to-all communication.
+
+    This factory is intentionally separate from registration so its distributed
+    layout and autograd behavior can be tested with a small PyTorch attention
+    reference on CPU-only CI.
+    """
+    import os
+
+    import torch.distributed as dist
+
+    from .cp_comm import SeqAllToAll4D
+
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError(
+            "Ulysses attention must be registered after torch.distributed is initialized."
+        )
+
+    cp_size = dist.get_world_size(cp_group)
+    if cp_size < 2:
+        raise ValueError(
+            "Ulysses attention requires a context-parallel group with at least two ranks."
+        )
+
+    seen = 0
+
+    def ulysses_attention(module, query, key, value, attention_mask=None, **kwargs):
+        nonlocal seen
+        seen += 1
+
+        if query.ndim != 4 or key.ndim != 4 or value.ndim != 4:
+            raise ValueError(
+                "Ulysses attention expects Q, K, and V in (batch, heads, sequence, dim) layout."
+            )
+        if key.shape != value.shape:
+            raise ValueError(
+                f"K and V must have the same shape, got {key.shape} and {value.shape}."
+            )
+        if query.shape[0] != key.shape[0] or query.shape[2:] != key.shape[2:]:
+            raise ValueError(
+                f"Q and K/V batch, sequence, and head dimensions must match: {query.shape}, {key.shape}."
+            )
+        if attention_mask is not None:
+            raise NotImplementedError(
+                "The dense Ulysses adapter currently supports kernel-owned causal/sliding masks only. "
+                "Use the varlen adapter for packed samples."
+            )
+
+        num_query_heads = query.shape[1]
+        num_kv_heads = key.shape[1]
+        if num_query_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"num_query_heads ({num_query_heads}) must be divisible by num_kv_heads ({num_kv_heads})."
+            )
+
+        # When a Gemma global-attention layer has fewer KV heads than CP ranks,
+        # expand K/V to MHA before scattering. This avoids empty all-to-all chunks.
+        if num_kv_heads < cp_size:
+            kv_repeat = num_query_heads // num_kv_heads
+            key = key.repeat_interleave(kv_repeat, dim=1)
+            value = value.repeat_interleave(kv_repeat, dim=1)
+            num_kv_heads = key.shape[1]
+
+        if num_query_heads % cp_size != 0 or num_kv_heads % cp_size != 0:
+            raise ValueError(
+                "Ulysses requires the post-replication Q and KV head counts to be divisible by "
+                f"cp_size={cp_size}, got Hq={num_query_heads} and Hkv={num_kv_heads}."
+            )
+
+        if seen <= 6 and os.environ.get("CP_DEBUG", "0") == "1":
+            if dist.get_rank() == 0:
+                print(
+                    f"[triton_gqa][cp] call={seen} q={tuple(query.shape)} "
+                    f"k={tuple(key.shape)} sliding_window={kwargs.get('sliding_window')}",
+                    flush=True,
+                )
+
+        # (B, H, N_local, D) -> (B, H/cp, N_full, D)
+        query = SeqAllToAll4D.apply(cp_group, query, 1, 2)
+        key = SeqAllToAll4D.apply(cp_group, key, 1, 2)
+        value = SeqAllToAll4D.apply(cp_group, value, 1, 2)
+
+        result = attention_fn(module, query, key, value, attention_mask=None, **kwargs)
+        output = result[0] if isinstance(result, tuple) else result
+        if output.ndim != 4:
+            raise ValueError(
+                f"The wrapped attention must return a 4D output, got shape {output.shape}."
+            )
+
+        # Transformers attention functions return (B, N_full, H/cp, D).
+        output = output.transpose(1, 2).contiguous()
+        output = SeqAllToAll4D.apply(cp_group, output, 2, 1)
+        output = output.transpose(1, 2).contiguous()
+        return output, None
+
+    return ulysses_attention
 
 
 def register_triton_attention_ulysses(
@@ -221,54 +347,7 @@ def register_triton_attention_ulysses(
     gathers seq dim across `cp_group`, runs local attention on the full seq
     with a head-shard, then inverts the all-to-all.
     """
-    import os as _os
-
-    import torch.distributed as _dist
-
-    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-
-    from .cp_comm import SeqAllToAll4D
-
-    _seen = {"n": 0}
-
-    def _ulysses_wrapped(module, query, key, value, attention_mask=None, **kwargs):
-        _seen["n"] += 1
-        n = _seen["n"]
-        if n <= 6 and _os.environ.get("CP_DEBUG", "0") == "1":
-            if not _dist.is_initialized() or _dist.get_rank() == 0:
-                print(
-                    f"[CP_DBG][rank0] ulysses_wrapped #{n} entry "
-                    f"q={tuple(query.shape)} k={tuple(key.shape)} v={tuple(value.shape)} "
-                    f"slide={kwargs.get('sliding_window', None)}",
-                    flush=True,
-                )
-        # GQA + Ulysses: when num_kv_heads < cp_size, replicate K/V to match
-        # Q heads before the all-to-all (avoids empty NCCL chunks).
-        cp_size = _dist.get_world_size(cp_group)
-        h_q = query.shape[1]
-        h_kv = key.shape[1]
-        if h_kv < cp_size:
-            kv_repeat = h_q // h_kv
-            key = key.repeat_interleave(kv_repeat, dim=1)
-            value = value.repeat_interleave(kv_repeat, dim=1)
-            if n <= 6 and _os.environ.get("CP_DEBUG", "0") == "1":
-                if not _dist.is_initialized() or _dist.get_rank() == 0:
-                    print(
-                        f"[CP_DBG][rank0] ulysses_wrapped #{n} KV-replicated "
-                        f"by {kv_repeat}x → k={tuple(key.shape)}",
-                        flush=True,
-                    )
-        # (B, H, N_local, D) -> (B, H/cp, N_full, D)
-        q = SeqAllToAll4D.apply(cp_group, query, 1, 2)
-        k = SeqAllToAll4D.apply(cp_group, key, 1, 2)
-        v = SeqAllToAll4D.apply(cp_group, value, 1, 2)
-        out, _ = triton_gqa_attention(module, q, k, v, attention_mask=None, **kwargs)
-        out = out.transpose(1, 2).contiguous()
-        out = SeqAllToAll4D.apply(cp_group, out, 2, 1)
-        out = out.transpose(1, 2).contiguous()
-        return out, None
-
-    ALL_ATTENTION_FUNCTIONS[name] = _ulysses_wrapped
+    _register_attention(name, _build_ulysses_attention(cp_group))
 
 
 # =====================================================================
@@ -302,6 +381,7 @@ def cu_seqlens_from_2d_indices(indices_2d):
         cu_seqlens: int32 (num_samples+1,), total_valid: int
     """
     import torch
+
     indices = indices_2d.squeeze(0) if indices_2d.dim() == 2 else indices_2d
     mask = indices != 0
     total_valid = int(mask.sum().item())
@@ -312,7 +392,9 @@ def cu_seqlens_from_2d_indices(indices_2d):
     boundaries = [0]
     for uid in unique_ids:
         boundaries.append(boundaries[-1] + int((valid_indices == uid).sum().item()))
-    return torch.tensor(boundaries, dtype=torch.int32, device=indices.device), total_valid
+    return torch.tensor(
+        boundaries, dtype=torch.int32, device=indices.device
+    ), total_valid
 
 
 def triton_gqa_varlen_attention(
@@ -340,18 +422,26 @@ def triton_gqa_varlen_attention(
     if state is None and attention_mask is not None and attention_mask.dim() == 2:
         cu, total = cu_seqlens_from_2d_indices(attention_mask)
         if total > 0:
-            max_sl = max(int(cu[i+1] - cu[i]) for i in range(cu.numel() - 1))
+            max_sl = max(int(cu[i + 1] - cu[i]) for i in range(cu.numel() - 1))
             state = (cu, max_sl)
 
     if state is None:
-        return triton_gqa_attention(module, query, key, value, attention_mask,
-                                    dropout=dropout, scaling=scaling,
-                                    softcap=softcap, sliding_window=sliding_window,
-                                    **kwargs)
+        return triton_gqa_attention(
+            module,
+            query,
+            key,
+            value,
+            attention_mask,
+            dropout=dropout,
+            scaling=scaling,
+            softcap=softcap,
+            sliding_window=sliding_window,
+            **kwargs,
+        )
 
     cu_seqlens, max_seqlen = state
 
-    scale = scaling if scaling is not None else module.head_dim ** -0.5
+    scale = scaling if scaling is not None else module.head_dim**-0.5
     default_scale = query.shape[-1] ** -0.5
     if scale != default_scale:
         query = query * (scale / default_scale)
@@ -370,8 +460,13 @@ def triton_gqa_varlen_attention(
     # cu_seqlens already includes dummy padding sample (set by trainer)
     with torch.cuda.device(query.device):
         out_packed = flash_attn_gqa_varlen(
-            q_packed, k_packed, v_packed,
-            cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
+            q_packed,
+            k_packed,
+            v_packed,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
             causal=getattr(module, "is_causal", True),
             window_size=slide,
         )
@@ -383,8 +478,7 @@ def triton_gqa_varlen_attention(
 
 def register_triton_attention_varlen(name: str = "triton_gqa_varlen") -> None:
     """Register the varlen adapter."""
-    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-    ALL_ATTENTION_FUNCTIONS[name] = triton_gqa_varlen_attention
+    _register_attention(name, triton_gqa_varlen_attention)
 
 
 def register_triton_attention_varlen_ulysses(
@@ -395,23 +489,32 @@ def register_triton_attention_varlen_ulysses(
     Wraps each attention call with all-to-all (scatter heads, gather tokens),
     runs varlen attention on the reassembled full sequence, then inverses.
     """
-    import os as _os
     import torch
     import torch.distributed as _dist
-    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
     from .cp_comm import SeqAllToAll4D
     from .attention import flash_attn_gqa_varlen
 
-    _seen = {"n": 0}
-
-    def _varlen_ulysses_wrapped(module, query, key, value, attention_mask=None, **kwargs):
-        _seen["n"] += 1
-        n = _seen["n"]
+    def _varlen_ulysses_wrapped(
+        module, query, key, value, attention_mask=None, **kwargs
+    ):
         cp_size = _dist.get_world_size(cp_group)
+
+        if query.shape[0] != 1 or key.shape[0] != 1 or value.shape[0] != 1:
+            raise ValueError(
+                "The varlen Ulysses adapter requires batch_size=1 packed input."
+            )
+        if kwargs.get("softcap") is not None:
+            raise NotImplementedError(
+                "triton_gqa_varlen_ulysses does not support softcap"
+            )
+        if kwargs.get("dropout", 0.0) != 0.0:
+            raise NotImplementedError(
+                "triton_gqa_varlen_ulysses does not support attention dropout"
+            )
 
         scale = kwargs.get("scaling", None)
         if scale is None:
-            scale = module.head_dim ** -0.5
+            scale = module.head_dim**-0.5
         default_scale = query.shape[-1] ** -0.5
         if scale != default_scale:
             query = query * (scale / default_scale)
@@ -423,11 +526,21 @@ def register_triton_attention_varlen_ulysses(
         B, H_Q, N_local, D = query.shape
         H_KV = key.shape[1]
 
+        if H_Q % H_KV != 0:
+            raise ValueError(f"H_Q ({H_Q}) must be divisible by H_KV ({H_KV}).")
+
         # KV replication for GQA when H_KV < cp_size
         if H_KV < cp_size:
             kv_rep = H_Q // H_KV
             key = key.repeat_interleave(kv_rep, dim=1)
             value = value.repeat_interleave(kv_rep, dim=1)
+            H_KV = key.shape[1]
+
+        if H_Q % cp_size != 0 or H_KV % cp_size != 0:
+            raise ValueError(
+                f"Post-replication head counts must be divisible by cp_size={cp_size}, "
+                f"got H_Q={H_Q}, H_KV={H_KV}."
+            )
 
         # Reshape to packed: (B=1, H, N_local, D) -> (N_local, H, D)
         q_local = query.squeeze(0).permute(1, 0, 2).contiguous()
@@ -445,14 +558,22 @@ def register_triton_attention_varlen_ulysses(
         if state is not None:
             cu_seqlens, max_seqlen = state
         else:
-            cu_seqlens = torch.tensor([0, N_full], dtype=torch.int32, device=q_full.device)
+            cu_seqlens = torch.tensor(
+                [0, N_full], dtype=torch.int32, device=q_full.device
+            )
             max_seqlen = N_full
 
         with torch.cuda.device(query.device):
             out_full = flash_attn_gqa_varlen(
-                q_full.contiguous(), k_full.contiguous(), v_full.contiguous(),
-                cu_seqlens, cu_seqlens, max_seqlen, max_seqlen,
-                causal=is_causal, window_size=slide,
+                q_full.contiguous(),
+                k_full.contiguous(),
+                v_full.contiguous(),
+                cu_seqlens,
+                cu_seqlens,
+                max_seqlen,
+                max_seqlen,
+                causal=is_causal,
+                window_size=slide,
             )
 
         # Inverse all-to-all: scatter tokens (dim=0), gather heads (dim=1)
@@ -463,7 +584,7 @@ def register_triton_attention_varlen_ulysses(
         out = out.transpose(1, 2).contiguous()
         return out, None
 
-    ALL_ATTENTION_FUNCTIONS[name] = _varlen_ulysses_wrapped
+    _register_attention(name, _varlen_ulysses_wrapped)
 
 
 def patch_transformers_5_5_4_flash_attn_key() -> None:
@@ -474,6 +595,7 @@ def patch_transformers_5_5_4_flash_attn_key() -> None:
     Safe to call multiple times (uses `setdefault`).
     """
     from transformers.utils.import_utils import PACKAGE_DISTRIBUTION_MAPPING
+
     PACKAGE_DISTRIBUTION_MAPPING.setdefault("flash_attn", ["flash-attn"])
 
 
@@ -489,6 +611,7 @@ class _SharedKVStatesHolder:
     Subscript ops `[idx]` are routed to an internal dict to match the original
     `shared_kv_states: dict[int, tuple[K, V]]` contract used by Gemma-4 code.
     """
+
     __slots__ = ("_d",)
 
     def __init__(self):
@@ -549,19 +672,29 @@ def patch_gemma4_shared_kv_states_for_fsdp2() -> None:
         **kwargs,
     ):
         if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
         if input_ids is not None:
             inputs_embeds = self.embed_tokens(input_ids)
         if self.hidden_size_per_layer_input:
             if per_layer_inputs is None:
                 per_layer_inputs = self.get_per_layer_inputs(input_ids, inputs_embeds)
-            per_layer_inputs = self.project_per_layer_inputs(inputs_embeds, per_layer_inputs)
+            per_layer_inputs = self.project_per_layer_inputs(
+                inputs_embeds, per_layer_inputs
+            )
         if use_cache and past_key_values is None:
             past_key_values = DynamicCache(config=self.config)
         if position_ids is None:
             import torch
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device)
+                + past_seen_tokens
+            )
             position_ids = position_ids.unsqueeze(0)
         if not isinstance(causal_mask_mapping := attention_mask, dict):
             mask_kwargs = {
@@ -578,14 +711,18 @@ def patch_gemma4_shared_kv_states_for_fsdp2() -> None:
         hidden_states = inputs_embeds
         position_embeddings = {}
         for layer_type in self.unique_layer_types:
-            position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
+            position_embeddings[layer_type] = self.rotary_emb(
+                hidden_states, position_ids, layer_type
+            )
 
         # THE FIX: use pytree-opaque holder so FSDP2's per-layer flatten/unflatten
         # preserves the dict-like state across decoder-layer boundaries.
         shared_kv_states = _SharedKVStatesHolder()
 
         for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
-            per_layer_input = per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
+            per_layer_input = (
+                per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
+            )
             hidden_states = decoder_layer(
                 hidden_states,
                 per_layer_input,
@@ -633,7 +770,9 @@ def patch_gemma4_image_group_ids_for_kernel() -> None:
         # (b) we actually have mm_token_type_ids (the prefill / training case
         # — incremental decode doesn't carry them).
         text_cfg = self.config.get_text_config()
-        wants_groups = getattr(text_cfg, "use_bidirectional_attention", None) == "vision"
+        wants_groups = (
+            getattr(text_cfg, "use_bidirectional_attention", None) == "vision"
+        )
         mm_token_type_ids = kwargs.get("mm_token_type_ids", None)
 
         token = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gemma-triton-flash-attn"
-version = "0.1.0"
+version = "0.2.0"
 description = "Triton Flash Attention for Gemma4-style GQA with large HEAD_DIM and sliding window support"
 readme = "README.md"
-requires-python = ">=3.9"
-license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
 authors = [{ name = "haojun" }]
 keywords = ["triton", "attention", "flash-attention", "gqa", "sliding-window", "gemma"]
 classifiers = [
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -27,10 +26,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-benchmark"]
+hf = ["transformers>=5.5.0"]
+dev = ["pytest", "pytest-benchmark", "transformers>=5.5.0"]
 
 [project.urls]
-Homepage = "https://github.com/user/gemma-triton-flash-attn"
+Homepage = "https://github.com/zzhhjjj/gemma-triton-flash-attn"
+Repository = "https://github.com/zzhhjjj/gemma-triton-flash-attn"
+Issues = "https://github.com/zzhhjjj/gemma-triton-flash-attn/issues"
 
 [tool.setuptools]
 packages = ["gemma_triton_flash_attn"]

--- a/tests/gemma4_integration/README.md
+++ b/tests/gemma4_integration/README.md
@@ -85,13 +85,13 @@ python test_memory.py
 
 ## How it works
 
-transformers 5.5.4 exposes a pluggable `ALL_ATTENTION_FUNCTIONS` registry.
-The test registers a `triton_gqa` entry pointing to our Triton kernel, then
-sets `model.config._attn_implementation = "triton_gqa"`. Every attention
-layer in the model routes through our kernel.
+transformers 5.5.4 exposes the public `AttentionInterface` registry. The test
+registers a `triton_gqa` entry pointing to our Triton kernel, then sets
+`model.config._attn_implementation = "triton_gqa"`. Every attention layer in
+the model routes through our kernel.
 
 ```python
-from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+from transformers import AttentionInterface
 from gemma_triton_flash_attn import flash_attn_gqa_train
 
 def triton_gqa_attention(module, query, key, value, attention_mask,
@@ -99,7 +99,7 @@ def triton_gqa_attention(module, query, key, value, attention_mask,
     # Bake scaling into q, call kernel, transpose output
     ...
 
-ALL_ATTENTION_FUNCTIONS["triton_gqa"] = triton_gqa_attention
+AttentionInterface.register("triton_gqa", triton_gqa_attention)
 model.config._attn_implementation = "triton_gqa"
 ```
 

--- a/tests/test_cp_cuda.py
+++ b/tests/test_cp_cuda.py
@@ -1,0 +1,155 @@
+"""NCCL/Triton correctness test for Gemma 4 Ulysses attention.
+
+Run on a machine with at least two CUDA devices:
+
+    torchrun --standalone --nproc-per-node=2 tests/test_cp_cuda.py
+
+The test also supports four or eight ranks, which exercise KV replication for
+Gemma 4 global layers with fewer KV heads than CP ranks.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+from gemma_triton_flash_attn import (
+    attention_gqa_ref,
+    attention_swa_ref,
+    register_triton_attention_ulysses,
+)
+
+
+def _cosine(left: torch.Tensor, right: torch.Tensor) -> torch.Tensor:
+    return F.cosine_similarity(left.float().flatten(), right.float().flatten(), dim=0)
+
+
+def _run_case(
+    *, head_dim: int, num_query_heads: int, num_kv_heads: int, sliding_window: int
+) -> None:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    # Keep the sequence at a representative attention tile size. Triton 3.2's
+    # Hopper layout pass can abort (rather than raise) for the otherwise unused
+    # D=256/BLOCK_Q=64 specialization produced by sequences shorter than 128.
+    sequence_length = 512
+
+    if num_query_heads % world_size != 0:
+        raise AssertionError(
+            f"Hq={num_query_heads} must be divisible by world_size={world_size}"
+        )
+
+    torch.manual_seed(2026 + head_dim + sliding_window)
+    query_full = torch.randn(
+        1,
+        num_query_heads,
+        sequence_length,
+        head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    key_full = torch.randn(
+        1,
+        num_kv_heads,
+        sequence_length,
+        head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    value_full = torch.randn_like(key_full)
+    grad_output_full = torch.randn(
+        1,
+        sequence_length,
+        num_query_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    query = (
+        query_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    )
+    key = key_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    value = (
+        value_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    )
+    grad_output = grad_output_full.chunk(world_size, dim=1)[rank].contiguous()
+
+    implementation = f"triton_gqa_ulysses_test_d{head_dim}_w{sliding_window}"
+    register_triton_attention_ulysses(dist.group.WORLD, name=implementation)
+    attention_fn = ALL_ATTENTION_FUNCTIONS.get_interface(implementation, None)
+    module = SimpleNamespace(head_dim=head_dim, is_causal=True)
+    output, _ = attention_fn(
+        module,
+        query,
+        key,
+        value,
+        attention_mask=None,
+        dropout=0.0,
+        scaling=None,
+        softcap=None,
+        sliding_window=sliding_window or None,
+    )
+    output.backward(grad_output)
+
+    query_ref = query_full.detach().clone().requires_grad_(True)
+    key_ref = key_full.detach().clone().requires_grad_(True)
+    value_ref = value_full.detach().clone().requires_grad_(True)
+    if sliding_window:
+        output_ref = attention_swa_ref(query_ref, key_ref, value_ref, sliding_window)
+    else:
+        output_ref = attention_gqa_ref(query_ref, key_ref, value_ref, causal=True)
+
+    output_ref = output_ref.transpose(1, 2).contiguous()
+    output_ref.backward(grad_output_full)
+
+    local_output_ref = output_ref.chunk(world_size, dim=1)[rank]
+    similarities = torch.stack(
+        [
+            _cosine(output, local_output_ref),
+            _cosine(query.grad, query_ref.grad.chunk(world_size, dim=2)[rank]),
+            _cosine(key.grad, key_ref.grad.chunk(world_size, dim=2)[rank]),
+            _cosine(value.grad, value_ref.grad.chunk(world_size, dim=2)[rank]),
+        ]
+    )
+    dist.all_reduce(similarities, op=dist.ReduceOp.MIN)
+    if torch.any(similarities < 0.999):
+        raise AssertionError(
+            f"D={head_dim}, window={sliding_window}: minimum output/dQ/dK/dV cosine values "
+            f"were {similarities.tolist()}"
+        )
+
+    if rank == 0:
+        print(
+            f"PASS D={head_dim} Hq:Hkv={num_query_heads}:{num_kv_heads} "
+            f"window={sliding_window} cos={similarities.tolist()}",
+            flush=True,
+        )
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError(
+            "This test requires CUDA and must be launched with torchrun."
+        )
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    try:
+        # Gemma 4 sliding attention: D=256 and a finite causal window.
+        _run_case(head_dim=256, num_query_heads=8, num_kv_heads=4, sliding_window=128)
+        dist.barrier()
+        # Gemma 4 global attention: D=512 and Hkv < CP on four-rank runs.
+        _run_case(head_dim=512, num_query_heads=8, num_kv_heads=1, sliding_window=0)
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cp_distributed.py
+++ b/tests/test_cp_distributed.py
@@ -1,0 +1,156 @@
+"""CPU distributed tests for the Ulysses adapter and its autograd path."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from gemma_triton_flash_attn.hf_integration import (
+    _build_ulysses_attention,
+    register_triton_attention,
+    register_triton_attention_varlen,
+    triton_gqa_attention,
+    triton_gqa_varlen_attention,
+)
+
+
+def _torch_gqa_attention(
+    module, query, key, value, attention_mask=None, scaling=None, **kwargs
+):
+    """Small differentiable attention reference matching the HF adapter contract."""
+    del module, kwargs
+    if attention_mask is not None:
+        raise AssertionError("The Ulysses unit test expects kernel-owned masking.")
+
+    groups = query.shape[1] // key.shape[1]
+    key = key.repeat_interleave(groups, dim=1)
+    value = value.repeat_interleave(groups, dim=1)
+    scale = scaling if scaling is not None else query.shape[-1] ** -0.5
+    scores = torch.matmul(query, key.transpose(-2, -1)) * scale
+    causal = torch.ones(
+        scores.shape[-2:], dtype=torch.bool, device=scores.device
+    ).tril()
+    scores = scores.masked_fill(~causal, torch.finfo(scores.dtype).min)
+    probabilities = torch.softmax(scores, dim=-1)
+    output = torch.matmul(probabilities, value)
+    return output.transpose(1, 2).contiguous(), None
+
+
+def _run_case(rank: int, world_size: int, head_dim: int, num_kv_heads: int) -> None:
+    torch.manual_seed(2026 + head_dim + num_kv_heads)
+    batch_size, num_query_heads, sequence_length = 1, 8, 8
+    query_full = (
+        torch.randn(batch_size, num_query_heads, sequence_length, head_dim) * 0.1
+    )
+    key_full = torch.randn(batch_size, num_kv_heads, sequence_length, head_dim) * 0.1
+    value_full = torch.randn(batch_size, num_kv_heads, sequence_length, head_dim) * 0.1
+
+    query = (
+        query_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    )
+    key = key_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    value = (
+        value_full.chunk(world_size, dim=2)[rank].detach().clone().requires_grad_(True)
+    )
+
+    module = SimpleNamespace(head_dim=head_dim, is_causal=True)
+    ulysses_attention = _build_ulysses_attention(dist.group.WORLD, _torch_gqa_attention)
+    output, _ = ulysses_attention(module, query, key, value, scaling=head_dim**-0.5)
+    output.square().sum().backward()
+
+    query_ref = query_full.detach().clone().requires_grad_(True)
+    key_ref = key_full.detach().clone().requires_grad_(True)
+    value_ref = value_full.detach().clone().requires_grad_(True)
+    output_ref, _ = _torch_gqa_attention(
+        module,
+        query_ref,
+        key_ref,
+        value_ref,
+        scaling=head_dim**-0.5,
+    )
+    output_ref.square().sum().backward()
+
+    torch.testing.assert_close(
+        output, output_ref.chunk(world_size, dim=1)[rank], rtol=1e-5, atol=1e-6
+    )
+    torch.testing.assert_close(
+        query.grad, query_ref.grad.chunk(world_size, dim=2)[rank], rtol=1e-5, atol=1e-6
+    )
+    torch.testing.assert_close(
+        key.grad, key_ref.grad.chunk(world_size, dim=2)[rank], rtol=1e-5, atol=1e-6
+    )
+    torch.testing.assert_close(
+        value.grad, value_ref.grad.chunk(world_size, dim=2)[rank], rtol=1e-5, atol=1e-6
+    )
+
+
+def _distributed_worker(rank: int, world_size: int, rendezvous_file: str) -> None:
+    os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        # Gemma 4 sliding shape: KV heads divide CP.
+        _run_case(rank, world_size, head_dim=256, num_kv_heads=4)
+        dist.barrier()
+        # Gemma 4 global shape: KV heads are fewer than CP and must be replicated.
+        _run_case(rank, world_size, head_dim=512, num_kv_heads=1)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_attention_registration_uses_public_interface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def record_registration(name, attention_fn):
+        calls.append((name, attention_fn))
+
+    monkeypatch.setattr("transformers.AttentionInterface.register", record_registration)
+    register_triton_attention("test_triton_gqa")
+    register_triton_attention_varlen("test_triton_gqa_varlen")
+
+    assert calls == [
+        ("test_triton_gqa", triton_gqa_attention),
+        ("test_triton_gqa_varlen", triton_gqa_varlen_attention),
+    ]
+
+
+def test_ulysses_forward_backward_matches_full_sequence_reference() -> None:
+    world_size = 2
+    with tempfile.TemporaryDirectory() as temp_dir:
+        rendezvous_file = str(Path(temp_dir) / "distributed_init")
+        mp.spawn(
+            _distributed_worker,
+            args=(world_size, rendezvous_file),
+            nprocs=world_size,
+            join=True,
+        )
+
+
+def test_ulysses_rejects_nondivisible_heads() -> None:
+    if not dist.is_available():
+        pytest.skip("torch.distributed is unavailable")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        rendezvous_file = str(Path(temp_dir) / "single_rank_init")
+        os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
+        dist.init_process_group(
+            "gloo", init_method=f"file://{rendezvous_file}", rank=0, world_size=1
+        )
+        try:
+            with pytest.raises(ValueError, match="at least two ranks"):
+                _build_ulysses_attention(dist.group.WORLD, _torch_gqa_attention)
+        finally:
+            dist.destroy_process_group()


### PR DESCRIPTION
## Summary

- register the Hugging Face attention implementations through the public
  `AttentionInterface.register()` API;
- harden the Ulysses Q/K/V all-to-all path, including explicit divisibility
  checks and KV-head expansion when the CP degree exceeds the KV-head count;
- expose documented dense and variable-length Ulysses registration APIs;
- add distributed Gloo and NCCL/Triton forward/backward equivalence tests;
- prepare the package metadata, documentation, and Apache-2.0 license for the
  `0.2.0` release.

## Motivation

This makes the existing Gemma 4 attention kernels usable as a supported
Ulysses-style context-parallel backend instead of relying on private
Transformers registry mutation. It is the attention-package prerequisite for
the LLaMA Factory Gemma 4 context-parallel proposal:
https://github.com/hiyouga/LlamaFactory/issues/10474

The integration covers Gemma 4 global attention (`HEAD_DIM=512`) and sliding
attention (`HEAD_DIM=256`), including the MoE configurations where global
layers can have fewer KV heads than CP ranks.

## Validation

- `pytest -q tests/test_cp_distributed.py`: **3 passed**;
- remaining single-GPU kernel/integration regressions: **19 passed**;
- NCCL/Triton Ulysses at CP=2/4/8 for D=256 sliding and D=512 global
  attention: all passed, worst output/gradient cosine **0.9999905**;
- tiny high-precision dense and MoE optimizer equivalence at CP=2/4/8:
  maximum loss delta **4.77e-7**, maximum gradient relative L2 **8.30e-7**,
  and no routing mismatches;
- 8-GPU full-SFT validation on Gemma 4 dense and MoE across
  C1/D8/G1, C2/D4/G2, C4/D2/G4, and C8/D1/G8 for 10 optimizer steps at an
  8,192-token active context and effective unique batch size 8.

The full-SFT runs remained finite and stable. The maximum loss deviation from
the C1 baseline was 1.41% for dense and 3.02% for MoE; the larger MoE spread
was localized to BF16 top-k router boundary changes after optimizer updates,
while the first-step selected gradient-norm deviation remained below 0.41%.

## Current scope

The dense Ulysses path intentionally rejects explicit attention masks. Packed
sequences use the separate variable-length registration. Unsupported dropout
and softcap configurations continue to fail loudly.

## Maintenance note

This PR is primarily for upstream visibility and possible reuse. There is no
expectation that the original repository owner merge, release, or maintain
these changes. I will maintain the context-parallel integration and its
`v0.2.0` release from
https://github.com/StevenShi-23/gemma-triton-flash-attn to support the LLaMA
Factory work. Please feel free to merge or cherry-pick it if useful, or leave
it unmerged otherwise.
